### PR TITLE
Correct help messages for embedding in newrelic-cli

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ type userFlags struct {
 	BrowserURL         string
 	AttachmentEndpoint string
 	Suites             string
+	InNewRelicCLI	   bool
 }
 
 type ConfigFlag struct {
@@ -202,6 +203,8 @@ func ParseFlags() {
 		Flags.Override = "Browser/Agent/GetSource.url=" + Flags.BrowserURL + "," + Flags.Override
 		Flags.Tasks = "Browser/Agent/Detect," + Flags.Tasks
 	}
+
+	Flags.InNewRelicCLI = (os.Getenv("NEWRELIC_CLI_SUBPROCESS") != "")
 }
 
 // UsagePayload gathers and sanitizes user command line input

--- a/core.go
+++ b/core.go
@@ -110,7 +110,15 @@ func main() {
 		}
 
 		if config.Flags.Suites == "" && config.Flags.Tasks == "" {
-			log.Infof("\n\nTo diagnose a specific product or issue, see task suites options: '%s -h suites'\n\n", os.Args[0])
+			var command, option string
+			if config.Flags.InNewRelicCLI {
+				command = "newrelic diagnose run"
+				option = "--list-suites"
+			} else {
+				command = os.Args[0]
+				option = "-h suites"
+			}
+			log.Infof("\n\nTo diagnose a specific product or issue, see task suites options: '%s %s'\n\n", command, option)
 		}
 	}
 }

--- a/processOptions.go
+++ b/processOptions.go
@@ -112,7 +112,14 @@ func processHelp() {
 //infra			Infrastructure Agent
 func printSuites() {
 	log.Info("\nSuites are a targeted collection of diagnostic tasks.\n")
-	log.Infof("Usage: \n\t%s --suites [suite arguments] \nExample:\n\t%[1]s --suites \"java,infra\"\n", os.Args[0])
+	var command string
+	// Match help strings to context
+	if config.Flags.InNewRelicCLI {
+		command = "newrelic diagnose run"
+	} else {
+		command = os.Args[0]
+	}
+	log.Infof("Usage: \n\t%s --suites [suite arguments] \nExamples:\n\t%[1]s --suites java,infra\n\t%[1]s --suites python\n", command)
 	log.Info("\nUse the following arguments to select task suite(s) to run:\n")
 	log.Infof("%-18s%s\n\n", "Arguments:", "Diagnostics for:")
 
@@ -147,7 +154,7 @@ func printTasks() {
 
 	sort.Sort(tasks.ByIdentifier(allTasks))
 
-	log.Infof("There are %d tasks\n", len(allTasks))
+	log.Infof("There are %d tasks:\n", len(allTasks))
 
 	var lastTask tasks.Task
 	for index, task := range allTasks {

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -97,7 +98,13 @@ func processAutoVersionCheck(log logger.API, getOnlineVersion func(logger.API) s
 		if !config.Flags.VeryQuiet {
 			logVersionString(log)
 			log.Infof(color.ColorString(color.Yellow, "Version %s has been released and is newer than your version.\n"), onlineVersion)
-			log.Info("Please run with the -version flag to download the new release.")
+			var command string
+			if config.Flags.InNewRelicCLI {
+				command = "newrelic diagnose update"
+			} else {
+				command = fmt.Sprintf("%s -version", os.Args[0])
+			}
+			log.Infof("Please run '%s' to download the new release.", command)
 		}
 		return false
 	}


### PR DESCRIPTION
# Issue

When running under `newrelic-cli`, the `-help suites` option and the text shown at the end of the run gave the path to the nrdiag binary. This would be confusing when running from `newrelic-cli`. This change will also support a future "running under newrelic-cli" metric.