### PR TITLE
add comment about using a fork instead of the upstream repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # NR Diag
 
-NR Diag was built, and is maintained, by New Relic Global Technical Support. 
+NR Diag was built, and is maintained, by New Relic Global Technical Support.
 It is a diagnostic and troubleshooting tool used to find common issues with New Relic Supported Products and Projects. Great for apps not reporting data to New Relic. Issues with connectivity, [configuration](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#h2-validate-your-config-file-settings), and compatibility. If it finds an issue it will suggest resolutions and relevant documentation. If it can’t help you resolve the issue, the information it gathers will help when troubleshooting with New Relic Support.
 
 ## Installation
@@ -12,7 +12,7 @@ It is a diagnostic and troubleshooting tool used to find common issues with New 
 To install in a Docker container see [here](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#h2-run-new-relic-diagnostics-in-a-docker-container)
 
 1. Download a zip of the latest version and see changes in our [releases notes](https://docs.newrelic.com/docs/release-notes/platform-release-notes/diagnostics-release-notes)
-2. Extract the zip, and select the executable file for your OS. 
+2. Extract the zip, and select the executable file for your OS.
 3. Place the executable in your application's root directory. *(May not find all issues if located outside the apps root directory)*
 
 
@@ -21,15 +21,15 @@ To install in a Docker container see [here](https://docs.newrelic.com/docs/using
 NR Diag can help you troubleshoot issues and confirm that everything is working as expected. If after running NR Diag you think you are still having issues review [Global Technical Support options](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings) that may be available for your issue, NR Diag output can help us resolve issues faster so keep it around!
 *Optional, but highly recommended*: Temporarily raise the logging level for the New Relic agent for more complete troubleshooting. Instructions can be found in [this documentation](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/generate-new-relic-agent-logs-troubleshooting)
 
- ### Troubleshooting and Diagnostics 
- 1. Open an elevated command prompt 
- 2. Navigate to root directory of your application (or where ever you placed the NR Diag binary) 
- 3. Run `nrdiag` 
+ ### Troubleshooting and Diagnostics
+ 1. Open an elevated command prompt
+ 2. Navigate to root directory of your application (or where ever you placed the NR Diag binary)
+ 3. Run `nrdiag`
    * Target functionality by using cmd line args such as [suites to target specific products or issues](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#task-suites) or see [all cmd line argos](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#cli-options)
-4. Review results( [tips on interpreting output](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#interpret-output)). 
+4. Review results( [tips on interpreting output](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#interpret-output)).
 
 ### Working with Global Technical Support
-If after running NR Diag, reviewing the output, and attempting to resolve the issue you are still having difficulties understanding what the issue is, the data gathered by NR Diag can be used by Global Technical Support to help resolve the issue, often in quicker time then without the data. Note if you have fixed any issues called out by NR Diag, either rerun it or let us know what you tried or changed (up to date results ensure more accurate troubleshooting) 
+If after running NR Diag, reviewing the output, and attempting to resolve the issue you are still having difficulties understanding what the issue is, the data gathered by NR Diag can be used by Global Technical Support to help resolve the issue, often in quicker time then without the data. Note if you have fixed any issues called out by NR Diag, either rerun it or let us know what you tried or changed (up to date results ensure more accurate troubleshooting)
 If you have or are going to open a ticket with Global Technical Support, then [uploading the data gathered](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#attach-ticket-results) by NR Diag will as early as possible will speed up the troubleshooting process.
 To upload your results automatically to a New Relic Support ticket all you need to do is run nrdiag binary using the attachment flag `-a MY-ATTACHMENT-KEY` You can get your attachment key by viewing the ticket in the New Relic Support Portal. You can also request a support engineer to provide you the attachment key.
 
@@ -41,7 +41,11 @@ New Relic hosts and moderates an online forum where customers can interact with 
 
 ## Contributing
 Have you ever dealt with a New Relic installation and/or configuration issue? Do you have suggestions on how to automate those steps to diagnose and solve the issue? Then we would love for you to contribute to NR Diag (or at least file a very detailed feature request)! NR Diag's main goal is to speed up and simplify the resolution of issues, no matter if you are working on your own or with our Support teams.
-All the information on how to build a new health check using NR Diag, as well as the requirements to submit a PR, can be found in our docs directory. Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project. If you have any questions, or to execute our corporate CLA, required if your contribution is on behalf of a company, please drop us an email at opensource@newrelic.com.
+All the information on how to build a new health check using NR Diag, as well as the requirements to submit a PR, can be found in our docs directory. Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
+
+Aditionally, you'll have to fork this repo prior to cloning or you'll get a permissions error.
+
+If you have any questions, or to execute our corporate CLA, required if your contribution is on behalf of a company, please drop us an email at opensource@newrelic.com.
 
 ### Recommended Doc reading order
 1. [Contributing overview](./docs/Contributing.md)

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -37,19 +37,19 @@ We host a public Slack with a dedicated channel for contributors and maintainers
 * GNU Make
 * git
 * Docker
-
+* Fork this repo
 
 ### Guidance
 
-If you have an idea for a new health check or any additional steps nrdiag should take to validate that a New Relic product has been configured correctly, then you should build an NR Diag task, it's easy! 
+If you have an idea for a new health check or any additional steps nrdiag should take to validate that a New Relic product has been configured correctly, then you should build an NR Diag task, it's easy!
 
 All the docs provided in this directory are meant to guide you through how to build an NR Diag task and how to write appropriate tests for it. Those docs are very thorough, and were written considering contributors of all levels of technical knowledge.
 
-Besides the documentation itself, you can take a look at the files within the task directory, and soon you'll notice that each NR Diag task has a very clear pattern and structure that you can use as reference to build your own task. 
+Besides the documentation itself, you can take a look at the files within the task directory, and soon you'll notice that each NR Diag task has a very clear pattern and structure that you can use as reference to build your own task.
 
 One important thing to keep in mind is that we have already written a lot of good, basic health checks. Please make sure that your idea for a health check has not yet been implemented in one way or another in our tasks directory. If you do not find it and you are ready to start building your task, then take advantage of the helper functions provided in our taskHelpers files inside the tasks directory. This is boiler plate logic that we found is applicable and useful to most New Relic health checks.
 
-Additionally, take advantage of other NR diag tasks to build your own task on top of them. Imagine you want to build a task to validate that a customer is using only Node.js supported versions for the Node Agent, then you could use another nrdiag task that already gathers the Node version from customer's environment. To get more details on how take advantage of `upstream` tasks, take a look at the [code snippets in our Coding Guidelines.](https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/docs/Coding-Guidelines.md)  
+Additionally, take advantage of other NR diag tasks to build your own task on top of them. Imagine you want to build a task to validate that a customer is using only Node.js supported versions for the Node Agent, then you could use another nrdiag task that already gathers the Node version from customer's environment. To get more details on how take advantage of `upstream` tasks, take a look at the [code snippets in our Coding Guidelines.](https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/docs/Coding-Guidelines.md)
 
 
 ### Testing your task
@@ -71,4 +71,3 @@ previous release.  This doesn't mean that building with an older version of Go
 will not work, but we don't intend to support a Go version in this project that
 is not supported by the larger Go community.  Please see the [Go
 releases][go_releases] page for more details.
-


### PR DESCRIPTION
# Issue
Hi! I'd love to contribute to a New Relic project and work on one of the issues listed. But before doing that, I'd like to suggest a change in the documentation to mention that this org and repo requires contributors to fork a repo rather than using the upstream version.

I got a 403 when attempting to push a branch against the upstream-remote repo:

```
remote: Permission to newrelic/newrelic-diagnostics-cli.git denied to MikeBLambert.
fatal: unable to access 'https://github.com/newrelic/newrelic-diagnostics-cli.git/': The requested URL returned error: 403
```

# Goals
Mention that contributors are required to use a fork version of this repo in order to open a PR.

# Implementation Details
Change in the Readme.md file and Contributing.md

# How to Test