### PR TITLE
Collect sys props and use them in relevant tasks

### DIFF
--- a/processOptions.go
+++ b/processOptions.go
@@ -19,6 +19,9 @@ import (
 func validateHTTPProxy(proxy string) (bool, error) {
 
 	//Check just for instance of '//'
+	if !(strings.Contains(proxy, "//")) {
+		log.Fatalf("Your proxy URL does not include a protocol: %s\nPlease override this issue by running nrdiag with our proxy flag using a similar proxy format: ./nrdiag -proxy http://poxy_host:proxy_port", proxy)
+	}
 	splitURL := strings.Split(proxy, "//")
 	if len(splitURL) != 2 {
 		return false, errors.New("Proxy url expecting exactly one instance of '//'")
@@ -66,7 +69,6 @@ func processHTTPProxy() (bool, error) {
 	}
 	envProxy := os.Getenv("HTTP_PROXY")
 	if envProxy != "" {
-
 		//Check the final env proxy.
 		_, err := validateHTTPProxy(envProxy)
 		if err != nil {

--- a/registration/registration_test.go
+++ b/registration/registration_test.go
@@ -39,7 +39,7 @@ func TestRegisterDependentTasks(t *testing.T) {
 	AddIdentifierToQueue(tasks.IdentifierFromString("Base/Config/Validate"))
 	CompleteTaskRegistration()
 
-	if len(Work.WorkQueue) != 3 {
+	if len(Work.WorkQueue) != 4 { //the expected length of the queue may have to continue going up as Base/Config/Validate becomes dependent on new nrdiag tasks that must be run prior to it
 		t.Error("WorkQueue expected to have 3 items after adding Base/Config/Validate; has:", len(Work.WorkQueue))
 	}
 }
@@ -76,4 +76,3 @@ func TestTasksHaveValidExplain(t *testing.T) {
 		}
 	}
 }
-

--- a/tasks/base/config/appname.go
+++ b/tasks/base/config/appname.go
@@ -65,8 +65,8 @@ func (t BaseConfigAppName) Explain() string {
 func (t BaseConfigAppName) Dependencies() []string {
 	return []string{
 		"Base/Config/Validate",
-		"Base/Env/collectEnvVars",
-		"Base/Env/collectSysProps",
+		"Base/Env/CollectEnvVars",
+		"Base/Env/CollectSysProps",
 	}
 }
 
@@ -78,7 +78,7 @@ func (t BaseConfigAppName) Execute(options tasks.Options, upstream map[string]ta
 	if len(appNameInfoFromEnvVar.Name) > 0 {
 		return tasks.Result{
 			Status:  tasks.Success,
-			Summary: fmt.Sprintf("A unique application name was found through the New Relic' App name environment variable: %s", appNameInfoFromEnvVar.Name),
+			Summary: fmt.Sprintf("An application name was found through the New Relic' App name environment variable: %s", appNameInfoFromEnvVar.Name),
 			Payload: []AppNameInfo{appNameInfoFromEnvVar}, //though is a single item, we still add them to a slice of AppNameInfo to stay consistant with a future upstream payload type assertion
 		}
 	}
@@ -89,7 +89,7 @@ func (t BaseConfigAppName) Execute(options tasks.Options, upstream map[string]ta
 	if appname != "" {
 		return tasks.Result{
 			Status:  tasks.Success,
-			Summary: fmt.Sprintf("A unique application name was found through the a New Relic system property: %s", appname),
+			Summary: fmt.Sprintf("An application name was found through the a New Relic system property: %s", appname),
 			Payload: []AppNameInfo{AppNameInfo{Name: appname, FilePath: appNameSysProp}},
 		}
 	}
@@ -115,7 +115,7 @@ func (t BaseConfigAppName) Execute(options tasks.Options, upstream map[string]ta
 	if len(appNameInfosFromConfig) == 0 {
 		return tasks.Result{
 			Status:  tasks.Warning,
-			Summary: "No New Relic app names were found. Please ensure an app name is set in your New Relic agent configuration file or as a New Relic environment variable (NEW_RELIC_APP_NAME). Note: This health check does not account for Java System properties.",
+			Summary: "No New Relic app names were found. Please ensure an app name is set in your New Relic agent configuration file or as a New Relic environment variable (NEW_RELIC_APP_NAME).",
 			URL:     "https://docs.newrelic.com/docs/agents/manage-apm-agents/app-naming/name-your-application",
 		}
 	}

--- a/tasks/base/config/appname.go
+++ b/tasks/base/config/appname.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/logger"
@@ -143,7 +142,7 @@ func (t BaseConfigAppName) Execute(options tasks.Options, upstream map[string]ta
 
 	return tasks.Result{
 		Status:  tasks.Success,
-		Summary: fmt.Sprintf("%s unique application name(s) found: %s", strconv.Itoa(len(appNameInfosFromConfig)), appNameInfosFromConfig[0].Name),
+		Summary: fmt.Sprintf("%d unique application name(s) found: %s", len(appNameInfosFromConfig), appNameInfosFromConfig[0].Name),
 		Payload: appNameInfosFromConfig,
 	}
 }

--- a/tasks/base/config/appname.go
+++ b/tasks/base/config/appname.go
@@ -89,7 +89,7 @@ func (t BaseConfigAppName) Execute(options tasks.Options, upstream map[string]ta
 	if appname != "" {
 		return tasks.Result{
 			Status:  tasks.Success,
-			Summary: fmt.Sprintf("An application name was found through the a New Relic system property: %s", appname),
+			Summary: fmt.Sprintf("An application name was found through a New Relic system property: %s", appname),
 			Payload: []AppNameInfo{AppNameInfo{Name: appname, FilePath: appNameSysProp}},
 		}
 	}
@@ -141,7 +141,7 @@ func (t BaseConfigAppName) Execute(options tasks.Options, upstream map[string]ta
 
 	return tasks.Result{
 		Status:  tasks.Success,
-		Summary: fmt.Sprintf("%s unique application name(s) found.", strconv.Itoa(len(appNameInfosFromConfig))),
+		Summary: fmt.Sprintf("%s unique application name(s) found: %s", strconv.Itoa(len(appNameInfosFromConfig)), appNameInfosFromConfig[0].Name),
 		Payload: appNameInfosFromConfig,
 	}
 }

--- a/tasks/base/config/appname_test.go
+++ b/tasks/base/config/appname_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Base/Config/AppName", func() {
 							FilePath: "/nrdiag/fixtures/java/newrelic/newrelic.yml",
 						},
 					},
-					Summary: "1 unique application name(s) found.",
+					Summary: "1 unique application name(s) found: Custom AppName",
 				}
 
 				Expect(p.Execute(executeOptions, executeUpstream)).To(Equal(expectedResult))

--- a/tasks/base/config/appname_test.go
+++ b/tasks/base/config/appname_test.go
@@ -31,7 +31,8 @@ var _ = Describe("Base/Config/AppName", func() {
 		It("Should return a slice with dependencies", func() {
 			expectedDependencies := []string{
 				"Base/Config/Validate",
-				"Base/Env/collectEnvVars",
+				"Base/Env/CollectEnvVars",
+				"Base/Env/CollectSysProps",
 			}
 			Expect(p.Dependencies()).To(Equal(expectedDependencies))
 		})
@@ -111,6 +112,23 @@ var _ = Describe("Base/Config/AppName", func() {
 			It("Should return a payload with a formatted message and success status", func() {
 				executeOptions := tasks.Options{}
 				executeUpstream := map[string]tasks.Result{
+					"Base/Env/CollectEnvVars": tasks.Result{
+						Status: tasks.Success,
+						Payload: map[string]string{
+							"NEW_RELIC_LICENSE_KEY": "my-license-key",
+						},
+					},
+					"Base/Env/CollectSysProps": tasks.Result{
+						Status: tasks.Info,
+						Payload: []tasks.ProcIDSysProps{
+							tasks.ProcIDSysProps{
+								ProcID: 40149,
+								SysPropsKeyToVal: map[string]string{
+									"-Dnewrelic.config.appserver_dispatcher": "Apache Tomcat",
+								},
+							},
+						},
+					},
 					"Base/Config/Validate": tasks.Result{
 						Payload: []ValidateElement{
 							{
@@ -180,7 +198,61 @@ var _ = Describe("Base/Config/AppName", func() {
 							FilePath: "NEW_RELIC_APP_NAME",
 						},
 					},
-					Summary: "A unique application name was found through the New Relic' App name environment variable: mysolid-appname",
+					Summary: "An application name was found through the New Relic' App name environment variable: mysolid-appname",
+				}
+
+				Expect(p.Execute(executeOptions, executeUpstream)).To(Equal(expectedResult))
+			})
+		})
+		Context("If upstream finds a system property for app name", func() {
+			It("Should return a payload with the env var value and ignore values found in config files", func() {
+				executeOptions := tasks.Options{}
+				executeUpstream := map[string]tasks.Result{
+
+					"Base/Env/CollectEnvVars": tasks.Result{
+						Status: tasks.Success,
+						Payload: map[string]string{
+							"NEW_RELIC_LICENSE_KEY": "my-license-key",
+						},
+					},
+					"Base/Env/CollectSysProps": tasks.Result{
+						Status: tasks.Info,
+						Payload: []tasks.ProcIDSysProps{
+							tasks.ProcIDSysProps{
+								ProcID: 40149,
+								SysPropsKeyToVal: map[string]string{
+									"-Dnewrelic.config.app_name": "my-appname",
+								},
+							},
+						},
+					},
+					"Base/Config/Validate": tasks.Result{
+						Payload: []ValidateElement{
+							{
+								Config: ConfigElement{
+									FileName: "newrelic.yml",
+									FilePath: "/nrdiag/fixtures/java/newrelic/",
+								},
+								ParsedResult: tasks.ValidateBlob{
+									Key:      "newrelic.appname",
+									Path:     "",
+									RawValue: "Custom AppName",
+								},
+							},
+						},
+						Status: tasks.Success,
+					},
+				}
+
+				expectedResult := tasks.Result{
+					Status: tasks.Success,
+					Payload: []AppNameInfo{
+						{
+							Name:     "my-appname",
+							FilePath: "-Dnewrelic.config.app_name",
+						},
+					},
+					Summary: "An application name was found through the a New Relic system property: my-appname",
 				}
 
 				Expect(p.Execute(executeOptions, executeUpstream)).To(Equal(expectedResult))
@@ -210,7 +282,7 @@ var _ = Describe("Base/Config/AppName", func() {
 
 				expectedResult := tasks.Result{
 					Status:  tasks.Warning,
-					Summary: "No New Relic app names were found. Please ensure an app name is set in your New Relic agent configuration file or as a New Relic environment variable (NEW_RELIC_APP_NAME). Note: This health check does not account for Java System properties.",
+					Summary: "No New Relic app names were found. Please ensure an app name is set in your New Relic agent configuration file or as a New Relic environment variable (NEW_RELIC_APP_NAME).",
 					URL:     "https://docs.newrelic.com/docs/agents/manage-apm-agents/app-naming/name-your-application",
 				}
 

--- a/tasks/base/config/appname_test.go
+++ b/tasks/base/config/appname_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Base/Config/AppName", func() {
 							FilePath: "/nrdiag/fixtures/java/newrelic/newrelic.yml",
 						},
 					},
-					Summary: "1 unique application name(s) found.",
+					Summary: "1 unique application name(s) found: Custom AppName",
 				}
 
 				Expect(p.Execute(executeOptions, executeUpstream)).To(Equal(expectedResult))
@@ -251,7 +251,7 @@ var _ = Describe("Base/Config/AppName", func() {
 							FilePath: "NEW_RELIC_APP_NAME",
 						},
 					},
-					Summary: "An application name was found through the New Relic' App name environment variable: mysolid-appname",
+					Summary: "A unique application name was found through the New Relic App name environment variable: mysolid-appname",
 				}
 
 				Expect(p.Execute(executeOptions, executeUpstream)).To(Equal(expectedResult))
@@ -305,7 +305,7 @@ var _ = Describe("Base/Config/AppName", func() {
 							FilePath: "-Dnewrelic.config.app_name",
 						},
 					},
-					Summary: "An application name was found through the a New Relic system property: my-appname",
+					Summary: "An application name was found through a New Relic system property: my-appname",
 				}
 
 				Expect(p.Execute(executeOptions, executeUpstream)).To(Equal(expectedResult))

--- a/tasks/base/config/collect.go
+++ b/tasks/base/config/collect.go
@@ -200,7 +200,7 @@ func (p BaseConfigCollect) Execute(options tasks.Options, upstream map[string]ta
 				configPath, isPresent := process.SysPropsKeyToVal[configSysProp]
 				if isPresent {
 					//Example path: -Dnewrelic.config.file=/usr/local/newrelic/newrelic.yml
-					invalidConfigFiles, foundConfigs = appendToInvalidOrFoundConfigs(configPath, &warningSummaryOnInvalidFiles, invalidConfigFiles, foundConfigs) //add to list of foundConfigs or to list of invalidConfigFiles depending if the file can be collected //Also not passing a pointer to slices since slice it self is a pointer to bootstrap array
+					invalidConfigFiles, foundConfigs = appendToInvalidOrFoundConfigs(configPath, &warningSummaryOnInvalidFiles, invalidConfigFiles, foundConfigs) //add to list of foundConfigs or to list of invalidConfigFiles depending if the file can be collected
 				}
 			}
 		}

--- a/tasks/base/config/collect.go
+++ b/tasks/base/config/collect.go
@@ -14,6 +14,8 @@ import (
 
 var pathsToIgnore = []string{"node_modules"}
 
+var configSysProp = "-Dnewrelic.config.file"
+
 var configEnvVarKeys = []string{
 	"NEW_RELIC_HOME",        // Node, Java
 	"NEW_RELIC_CONFIG_FILE", // Python
@@ -84,6 +86,7 @@ func (p BaseConfigCollect) Dependencies() []string {
 	// no dependencies!
 	return []string{
 		"Base/Env/CollectEnvVars",
+		"Base/Env/CollectSysProps",
 	}
 }
 
@@ -186,6 +189,20 @@ func (p BaseConfigCollect) Execute(options tasks.Options, upstream map[string]ta
 			}
 		} else {
 			foundConfigs = append(foundConfigs, secureConfig)
+		}
+	}
+
+	//search for config file in New Relic System Property
+	if upstream["Base/Env/CollectSysProps"].Status == tasks.Info {
+		proccesses, ok := upstream["Base/Env/CollectSysProps"].Payload.([]tasks.ProcIDSysProps)
+		if ok {
+			for _, process := range proccesses {
+				configPath, isPresent := process.SysPropsKeyToVal[configSysProp]
+				if isPresent {
+					//-Dnewrelic.config.file=/usr/local/newrelic/newrelic.yml
+
+				}
+			}
 		}
 	}
 

--- a/tasks/base/config/integrationTests.yml
+++ b/tasks/base/config/integrationTests.yml
@@ -105,16 +105,13 @@
      - Success.*Base/Collector/Connect
      - http://user:password@hostname:port
     docker_cmd: ./nrdiag -p http://127.0.0.1:8888 && cat nrdiag-output.json
- -  test_name: ProxyDetectEnvironmentOverride
+ -  test_name: ProxyDetectwithHTTPProxyEnvVar
     dockerfile_lines:
      - COPY tasks/fixtures/integration/proxyDetect/newrelic-infra /app/newrelic-infra.yml
     log_entry_expected:
+     - Success.*Base/Config/ProxyDetect
      - Failure.*Base/Collector/Connect
      - tcp 127.0.0.1:8888
-    log_entry_not_expected:
-     - Success.*Base/Config/ProxyDetect
-     - Success.*Base/Collector/Connect
-     - http://user:password@hostname:port
     docker_cmd: HTTP_PROXY=http://127.0.0.1:8888 ./nrdiag && cat nrdiag-output.json
  -  test_name: ProxyDetectCLIEnvironmentOverride
     dockerfile_lines:

--- a/tasks/base/config/proxyDetect.go
+++ b/tasks/base/config/proxyDetect.go
@@ -168,9 +168,8 @@ func checkForHttpORHttpsProxies() (string, string) {
 }
 
 func getProxyConfig(validations []ValidateElement, options tasks.Options, upstream map[string]tasks.Result) (ProxyConfig, error) {
-	var proxyConfig ProxyConfig
 
-	proxyConfig = findProxyValuesFromEnvVars(upstream)
+	proxyConfig := findProxyValuesFromEnvVars(upstream)
 
 	for _, validation := range validations { // Go through each config file validation to see if the proxy is configured anywhere in there or to at least find out which agent are we dealing with based on the file extension
 		if filepath.Ext(validation.Config.FileName) != ".ini" && (proxyConfig != ProxyConfig{}) {

--- a/tasks/base/config/proxyDetect.go
+++ b/tasks/base/config/proxyDetect.go
@@ -192,6 +192,7 @@ func getProxyConfig(validations []ValidateElement, options tasks.Options, upstre
 		// now let's look into infra, .NET, PHP, minion and other standard settings
 		for _, proxyConfigKeys := range nrProxyConfigs {
 			proxyConfig, multipleProxyConfigs := findProxyValuesFromConfigFile(proxyConfigKeys, validation)
+			log.Debug("ProxyConfig found through config file: ", proxyConfig)
 			log.Debug("Detected multipleProxyConfigs: ", multipleProxyConfigs)
 			if proxyConfig.proxyHost != "" {
 				return proxyConfig, nil //return as soon as we have a match
@@ -213,7 +214,7 @@ func setProxyURL(proxy ProxyConfig) string {
 	var proxyURL string
 	if proxy.proxyUser != "" {
 		proxyURL += proxy.proxyUser
-		//No pass found case for combined auth in single key (e.g. private minion's proxyAuth)
+		//No password found case for combined auth in single key (e.g. private minion's proxyAuth)
 		if proxy.proxyPassword != "" {
 			proxyURL += ":" + proxy.proxyPassword
 		}
@@ -236,6 +237,7 @@ func setProxyURL(proxy ProxyConfig) string {
 	}
 	//default to http
 	proxyURL = "http://" + proxyURL
+	log.Debug("Setting proxy via detected config to", proxyURL)
 	return proxyURL
 }
 

--- a/tasks/base/config/proxyDetect.go
+++ b/tasks/base/config/proxyDetect.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,11 +11,65 @@ import (
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
-type proxyConfig struct {
+type ProxyConfig struct {
 	proxyHost     string
 	proxyPort     string
 	proxyUser     string
 	proxyPassword string
+	processID     int32
+}
+
+var proxyEnvVarsKeys = []string{
+	"NEW_RELIC_PROXY_HOST",     //Java, Node, Python, Ruby
+	"NEW_RELIC_PROXY_PASS",     //Node, Python, Ruby
+	"NEW_RELIC_PROXY_PORT",     //Java, Node, Python, Ruby
+	"NEW_RELIC_PROXY_URL",      //Node
+	"NEW_RELIC_PROXY_USER",     //Java, Node, Python, Ruby
+	"NEW_RELIC_PROXY_SCHEME",   //Java, Python : Setting proxy_scheme: "https" will allow the agent to connect through proxies using the HTTPS scheme
+	"NEW_RELIC_PROXY_PASSWORD", //Java
+}
+
+var proxySysPropsKeys = []string{
+	"-Dnewrelic.config.proxy_host", //=somehost.com
+	"-Dnewrelic.config.proxy_port",
+	"-Dnewrelic.config.proxy_user", //=username
+	"-Dnewrelic.config.proxy_password",
+}
+
+var proxyConfigKeys = []ProxyConfig{ //This is a slice with all the possible entries that we will search through
+	minionProxyKeys,
+	standardProxyKeys,
+	dotnetProxyKeys,
+	infraOrNodeProxyKeys,
+	phpProxyKeys,
+}
+
+var standardProxyKeys = ProxyConfig{ //This is the values used by Java, Ruby, Node, Python
+	proxyHost:     "proxy_host",
+	proxyPort:     "proxy_port",
+	proxyUser:     "proxy_user",
+	proxyPassword: "proxy_pass",
+}
+
+var dotnetProxyKeys = ProxyConfig{
+	proxyHost:     "-host",
+	proxyPort:     "-port",
+	proxyUser:     "-user",
+	proxyPassword: "-password",
+}
+
+var infraOrNodeProxyKeys = ProxyConfig{
+	proxyHost: "proxy", //Infra agent and Node support the single proxy item names (which take as a value a url: 'http://user:pass@10.0.0.1:8000/') or the standard config keys so we look for both. This setting will override the other standardProxyKeys in the config file
+}
+
+// minion has combined auth key "proxyAuth".
+var minionProxyKeys = ProxyConfig{
+	proxyHost: "proxy",
+	proxyUser: "proxyAuth",
+}
+
+var phpProxyKeys = ProxyConfig{
+	proxyHost: "newrelic.daemon.proxy",
 }
 
 // BaseConfigProxyDetect - Primary task to search for and find config file. Will optionally take command line input as source
@@ -36,12 +91,15 @@ func (p BaseConfigProxyDetect) Dependencies() []string {
 	// no dependencies!
 	return []string{
 		"Base/Config/Validate",
+		"Base/Env/CollectEnvVars",
+		"Base/Env/CollectSysProps",
 	}
 }
 
 // Execute - This task will search for config files based on the string array defined and walk the directory tree from the working directory searching for additional matches
 func (p BaseConfigProxyDetect) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
 	var result tasks.Result
+	//Check options to see if proxy was configured via command line or env
 
 	if envProxy := os.Getenv("HTTP_PROXY"); envProxy != "" {
 		log.Debug("Proxy set via ENV variable. Task did not run.")
@@ -62,26 +120,38 @@ func (p BaseConfigProxyDetect) Execute(options tasks.Options, upstream map[strin
 		//		log.Debug(configs) //This may be useful when debugging to log the entire results to the screen
 	}
 
-	//Check options to see if proxy was configured via command line or env
-
-	// Loop through validations to see if the proxy is configured anywhere
-
+	// Loop through validations to see if the proxy is configured anywhere in there or to at least find out which agent are we dealing with
 	for _, validation := range validations {
 
-		proxyValue, err := findProxyValues(validation, envOverride)
+		proxyConfigs, err := findProxyValues(validation, envOverride, upstream)
 		if err != nil {
 			log.Debug("Error getting proxy. Error was ", err)
 			result.Status = tasks.Warning
 			result.Summary = "Error retrieving proxy from config file" + err.Error()
 		}
-		log.Debug("execute proxyValue is", proxyValue)
-		if proxyValue.proxyHost != "" {
-			proxyURL := setProxyFromConfig(proxyValue)
-			result.Status = tasks.Success
-			result.Summary = "Set proxy to: " + proxyURL + " from file: " + validation.Config.FilePath + validation.Config.FileName
-			result.Payload = proxyValue
-			return result //Exit as soon as we set a proxy
+		log.Debug("execute proxyValue is", proxyConfigs)
+
+		proxySuccessSummary := ""
+		for _, proxyConfig := range proxyConfigs {
+			if proxyConfig.proxyHost != "" {
+				proxyURL := setProxyFromConfig(proxyConfig)
+				proxySuccessSummary = proxySuccessSummary + fmt.Sprintf("Set proxy to: %\n", proxyURL)
+			}
 		}
+		if len(proxySuccessSummary) > 0 {
+			return tasks.Result{
+				Status:  tasks.Success,
+				Summary: proxySuccessSummary,
+				Payload: proxyConfigs,
+			}
+		}
+		// if proxyValue.proxyHost != "" {
+		// 	proxyURL := setProxyFromConfig(proxyValue)
+		// 	result.Status = tasks.Success
+		// 	result.Summary = "Set proxy to: " + proxyURL + " from file: " + validation.Config.FilePath + validation.Config.FileName
+		// 	result.Payload = []proxyConfig{proxyValue}
+		// 	return result //Exit as soon as we set a proxy
+		// }
 
 	}
 
@@ -94,43 +164,7 @@ func (p BaseConfigProxyDetect) Execute(options tasks.Options, upstream map[strin
 	return result
 }
 
-var standardProxyKeys = proxyConfig{ //This is the values used by Java, Ruby
-	proxyHost:     "proxy_host",
-	proxyPort:     "proxy_port",
-	proxyUser:     "proxy_user",
-	proxyPassword: "proxy_pass",
-}
-
-var dotnetProxyKeys = proxyConfig{
-	proxyHost:     "-host",
-	proxyPort:     "-port",
-	proxyUser:     "-user",
-	proxyPassword: "-password",
-}
-
-var infraProxyKeys = proxyConfig{
-	proxyHost: "proxy", //node also supports the single proxy item names or the standard config keys so we look for both
-}
-
-// minion has combined auth key "proxyAuth".
-var minionProxyKeys = proxyConfig{
-	proxyHost: "proxy",
-	proxyUser: "proxyAuth",
-}
-
-var phpProxyKeys = proxyConfig{
-	proxyHost: "newrelic.daemon.proxy",
-}
-
-var proxyConfigKeys = []proxyConfig{ //This is a slice with all the possible entries that we will search through
-	minionProxyKeys,
-	standardProxyKeys,
-	dotnetProxyKeys,
-	infraProxyKeys,
-	phpProxyKeys,
-}
-
-func setProxyFromConfig(proxy proxyConfig) string {
+func setProxyFromConfig(proxy ProxyConfig) string {
 	//Build proxy url. Some agents and customers will preprend a protocol to their host configuration. So want to avoid building a url such as this one: http://https://myuser:mypassword@myproxy.mycompany.com:8080
 	var proxyURL string
 	defaultProxyProtocol := "http://"
@@ -161,37 +195,76 @@ func setProxyFromConfig(proxy proxyConfig) string {
 	return proxyURL
 }
 
-func findProxyValues(input ValidateElement, envOverride string) (proxyConfig, error) {
+func findProxyValues(fileElement ValidateElement, envOverride string, upstream map[string]tasks.Result) ([]ProxyConfig, error) {
 	//So first we build a map so we can track the results, using the proxy_host as the string of the map itself
-	var defaultProxyConfig proxyConfig
+	var defaultProxyConfig ProxyConfig
 
-	if filepath.Ext(input.Config.FileName) == ".yml" && input.Config.FileName != "newrelic-infra.yml" {
-		proxyConfig, err := findValueFromYml(input, envOverride)
-		if err != nil {
-			return proxyConfig, err
+	if filepath.Ext(fileElement.Config.FileName) == ".yml" && fileElement.Config.FileName != "newrelic-infra.yml" {
+		//applicable only to Java
+		proxyConfigs := findValueFromSysProps(upstream) //the only reason I am return an slice of ProxyConfigs is because I am assumming that in some crazy world you can have different JVM processes, each running with its own proxy server settings
+		if len(proxyConfigs) > 0 {
+			return proxyConfigs, nil
 		}
-		return proxyConfig, nil
+		//Check for proxy values in yml file, applicable to Java and Ruby
+		proxyConfig, err := findValueFromYml(fileElement, envOverride)
+		if err != nil {
+			return []ProxyConfig{proxyConfig}, err
+		}
+		return []ProxyConfig{proxyConfig}, nil
 	}
-
+	// now let's look into infra, .NET, PHP, minion and other standard settings
 	for _, proxyKey := range proxyConfigKeys {
-
-		proxyValues, proxyMap := findValueFromKeys(proxyKey, input)
-		log.Debug("Detected proxyValues", proxyValues)
+		proxyConfig, proxyMap := findValueFromKeys(proxyKey, fileElement)
+		log.Debug("Detected proxyConfig", proxyConfig)
 		log.Debug("Detected proxyMap", proxyMap)
 		if len(proxyMap) > 1 {
-			return defaultProxyConfig, errors.New("multiple proxy values")
+			return []ProxyConfig{defaultProxyConfig}, errors.New("multiple proxy values")
 		}
-		if proxyValues.proxyHost != "" {
-			return proxyValues, nil //return as soon as we have a match
+		if proxyConfig.proxyHost != "" {
+			return []ProxyConfig{proxyConfig}, nil //return as soon as we have a match
 		}
 	}
 
 	log.Debug("returning found proxy values of ", defaultProxyConfig)
-	return defaultProxyConfig, nil
+	return []ProxyConfig{defaultProxyConfig}, nil
 }
 
-func findValueFromYml(input ValidateElement, envOverride string) (proxyConfig, error) {
-	var returnProxyValues proxyConfig
+func findValueFromSysProps(upstream map[string]tasks.Result) []ProxyConfig {
+	proxyConfigs := []ProxyConfig{}
+
+	if upstream["Base/Env/CollectSysProps"].Status == tasks.Info {
+		processes, ok := upstream["Base/Env/CollectSysProps"].Payload.([]tasks.ProcIDSysProps)
+		if ok {
+			for _, process := range processes {
+				config := ProxyConfig{}
+				for _, proxySysPropKey := range proxySysPropsKeys {
+					proxySysPropVal, isPresent := process.SysPropsKeyToVal[proxySysPropKey]
+					if isPresent {
+						if strings.Contains(proxySysPropKey, "host") {
+							config.proxyHost = proxySysPropVal
+						} else if strings.Contains(proxySysPropKey, "port") {
+							config.proxyPort = proxySysPropVal
+						} else if strings.Contains(proxySysPropKey, "user") {
+							config.proxyUser = proxySysPropVal
+						} else {
+							config.proxyPassword = proxySysPropVal
+						}
+					}
+				}
+				if (config != ProxyConfig{}) { // we want at least one of the proxyConfig fiels to be populated
+					config.processID = process.ProcID
+					proxyConfigs = append(proxyConfigs, config)
+				}
+			}
+		}
+		return proxyConfigs
+	}
+
+	return proxyConfigs
+}
+
+func findValueFromYml(input ValidateElement, envOverride string) (ProxyConfig, error) {
+	var returnProxyValues ProxyConfig
 
 	proxyValues, proxyMap := findValueFromKeys(standardProxyKeys, input)
 	if proxyValues.proxyHost != "" {
@@ -228,26 +301,26 @@ func findValueFromYml(input ValidateElement, envOverride string) (proxyConfig, e
 	return returnProxyValues, nil
 }
 
-func findValueFromKeys(searchKeys proxyConfig, input ValidateElement) (proxyConfig, map[string]string) {
-	var proxyValues proxyConfig
+func findValueFromKeys(searchKeys ProxyConfig, input ValidateElement) (ProxyConfig, map[string]string) {
+	var proxyValues ProxyConfig
 	var combinedMap = make(map[string]string)
 
 	//This will return 1 or more found keys that we need to map to the slice
-	hostValue := input.ParsedResult.FindKey(searchKeys.proxyHost)
+	hostValues := input.ParsedResult.FindKey(searchKeys.proxyHost)
 
 	// call out to build the map from the value
 
-	for _, v := range hostValue {
-		if len(hostValue) == 1 {
+	for _, v := range hostValues {
+		if len(hostValues) == 1 {
 			proxyValues.proxyHost = v.Value()
 		} else {
 			combinedMap[v.PathAndKey()] = v.Value()
 		}
 	}
 	if searchKeys.proxyPort != "" {
-		portValue := input.ParsedResult.FindKey(searchKeys.proxyPort)
-		for _, v := range portValue {
-			if len(portValue) == 1 {
+		portValues := input.ParsedResult.FindKey(searchKeys.proxyPort)
+		for _, v := range portValues {
+			if len(portValues) == 1 {
 				proxyValues.proxyPort = v.Value()
 			} else {
 				combinedMap[v.PathAndKey()] = v.Value()
@@ -255,9 +328,9 @@ func findValueFromKeys(searchKeys proxyConfig, input ValidateElement) (proxyConf
 		}
 	}
 	if searchKeys.proxyUser != "" {
-		userValue := input.ParsedResult.FindKey(searchKeys.proxyUser)
-		for _, v := range userValue {
-			if len(userValue) == 1 {
+		userValues := input.ParsedResult.FindKey(searchKeys.proxyUser)
+		for _, v := range userValues {
+			if len(userValues) == 1 {
 				proxyValues.proxyUser = v.Value()
 			} else {
 				combinedMap[v.PathAndKey()] = v.Value()
@@ -265,18 +338,18 @@ func findValueFromKeys(searchKeys proxyConfig, input ValidateElement) (proxyConf
 		}
 	}
 	if searchKeys.proxyPassword != "" {
-		passValue := input.ParsedResult.FindKey(searchKeys.proxyPassword)
-		for _, v := range passValue {
-			if len(passValue) == 1 {
+		passValues := input.ParsedResult.FindKey(searchKeys.proxyPassword)
+		for _, v := range passValues {
+			if len(passValues) == 1 {
 				proxyValues.proxyPassword = v.Value()
 			} else {
 				combinedMap[v.PathAndKey()] = v.Value()
 			}
 		}
 		// Do second search for password because java and ruby are dumb and almost match
-		passwordValue := input.ParsedResult.FindKey(searchKeys.proxyPassword + "word")
-		for _, v := range passwordValue {
-			if len(passwordValue) == 1 {
+		passwordValues := input.ParsedResult.FindKey(searchKeys.proxyPassword + "word")
+		for _, v := range passwordValues {
+			if len(passwordValues) == 1 {
 				proxyValues.proxyPassword = v.Value()
 			} else {
 				combinedMap[v.PathAndKey()] = v.Value()
@@ -285,14 +358,13 @@ func findValueFromKeys(searchKeys proxyConfig, input ValidateElement) (proxyConf
 
 	}
 
-
 	log.Debug("combined proxy map is", combinedMap)
 	log.Debug("proxyValues found are", proxyValues)
 	return proxyValues, combinedMap
 }
 
-func convertToMapStruct(incomingMap map[string]string, proxyKey *proxyConfig) map[string]proxyConfig {
-	var returnedConfig = make(map[string]proxyConfig)
+func convertToMapStruct(incomingMap map[string]string, proxyKey *ProxyConfig) map[string]ProxyConfig {
+	var returnedConfig = make(map[string]ProxyConfig)
 
 	//We're going to default to assuming environment of prod
 	//support an override to pass in a different environment sectrion to activate but otherwise just use prod
@@ -313,7 +385,7 @@ func convertToMapStruct(incomingMap map[string]string, proxyKey *proxyConfig) ma
 	return returnedConfig
 }
 
-func setProxyMap(hostValue map[string]string, searchKey string, found *map[string]proxyConfig) {
+func setProxyMap(hostValue map[string]string, searchKey string, found *map[string]ProxyConfig) {
 	var prefixes []string
 
 	for key := range hostValue {

--- a/tasks/base/config/validateLicenseKey.go
+++ b/tasks/base/config/validateLicenseKey.go
@@ -154,7 +154,7 @@ func checkConfigFormat(licenseKey string, sources []string) (bool, string) {
 	if isFormatValid(sanitizedLicenseKey) {
 		return true, ""
 	}
-	errMsg := fmt.Sprintf("The license key found in\n %s \ndoes not have a valid format: %s. \nThe NR license key is 40 alphanumeric characters. \nReview this documentation to make sure that you have the proper format of a New Relic Personal API key: \nhttps://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys\n\n", strings.Join(sources, ",\n "), sanitizedLicenseKey)
+	errMsg := fmt.Sprintf("The license key found in %s does not have a valid format: %s. \nThe NR license key is 40 alphanumeric characters. \nReview this documentation to make sure that you have the proper format of a New Relic Personal API key: \nhttps://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys\n\n", strings.Join(sources, ",\n "), sanitizedLicenseKey)
 	return false, errMsg
 }
 

--- a/tasks/base/config/validateLicenseKey_test.go
+++ b/tasks/base/config/validateLicenseKey_test.go
@@ -3,9 +3,9 @@ package config
 import (
 	"errors"
 
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
 var _ = Describe("BaseConfigValidateLicenseKey", func() {
@@ -59,7 +59,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in` + "\n" + ` /usr/local/etc/php/conf.d/newrelic.ini ` + "\n" + `does not have a valid format: REPLACE_WITH_REAL_KEY. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
+				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in /usr/local/etc/php/conf.d/newrelic.ini does not have a valid format: REPLACE_WITH_REAL_KEY. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
 
 			})
 		})
@@ -80,7 +80,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 				}
 				p.validateAgainstAccount = func(map[string][]string) (map[string][]string, map[string][]string, error) {
 					validLKToSources := make(map[string][]string)
-          validLKToSources["08a2ad66c637a29c3982469a3fe8d1982d00NRAL"] = []string{"/data/www/myappname-production/releases/20191009171653/config/newrelic.yml"}
+					validLKToSources["08a2ad66c637a29c3982469a3fe8d1982d00NRAL"] = []string{"/data/www/myappname-production/releases/20191009171653/config/newrelic.yml"}
 
 					return validLKToSources, map[string][]string{}, nil
 				}
@@ -88,8 +88,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Success))
-        Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in /data/www/myappname-production/releases/20191009171653/config/newrelic.yml passed our validation check when verifying against your account:` + "\n" + ` 08a2ad66c637a29c3982469a3fe8d1982d00NRAL` + "\nNote: If your agent is reporting an 'Invalid license key' log entry for this valid License key, reach out to New Relic support to verify any issues in our end.\n\n"))
-
+				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in /data/www/myappname-production/releases/20191009171653/config/newrelic.yml passed our validation check when verifying against your account:` + "\n" + ` 08a2ad66c637a29c3982469a3fe8d1982d00NRAL` + "\nNote: If your agent is reporting an 'Invalid license key' log entry for this valid License key, reach out to New Relic support to verify any issues in our end.\n\n"))
 
 			})
 		})
@@ -102,7 +101,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 						Status: tasks.Success,
 						Payload: []LicenseKey{
 							LicenseKey{
-                Value:  `"08a2ad66c637a29c3982469a3fe8d1982d00NRAL"`,
+								Value:  `"08a2ad66c637a29c3982469a3fe8d1982d00NRAL"`,
 								Source: "/app/myappname/newrelic.ini",
 							},
 						},
@@ -116,8 +115,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Warning))
-        Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in /app/myappname/newrelic.ini has a valid New Relic format: "08a2ad66c637a29c3982469a3fe8d1982d00NRAL". ` + "\n" + `Though we ran into an error (Expected StatusCode < 300 got 500: {"success":false,"error":"Could not resolve license keys") while trying to validate against your account. Only if your agent is reporting an 'Invalid license key' log entry, reach out to New Relic Support.` + "\n\n"))
-
+				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in /app/myappname/newrelic.ini has a valid New Relic format: "08a2ad66c637a29c3982469a3fe8d1982d00NRAL". ` + "\n" + `Though we ran into an error (Expected StatusCode < 300 got 500: {"success":false,"error":"Could not resolve license keys") while trying to validate against your account. Only if your agent is reporting an 'Invalid license key' log entry, reach out to New Relic Support.` + "\n\n"))
 
 			})
 		})
@@ -130,7 +128,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 						Status: tasks.Success,
 						Payload: []LicenseKey{
 							LicenseKey{
-                Value:  `"eu01xx66c637a29c3982469a3fe8d1982d00NRAL"`,
+								Value:  `"eu01xx66c637a29c3982469a3fe8d1982d00NRAL"`,
 								Source: `C:\ProgramData\New Relic\.NET Agent\newrelic.config`,
 							},
 							LicenseKey{
@@ -142,15 +140,14 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 				}
 				p.validateAgainstAccount = func(map[string][]string) (map[string][]string, map[string][]string, error) {
 					invalidLKToSources := make(map[string][]string)
-          invalidLKToSources["eu01xx66c637a29c3982469a3fe8d1982d00NRAL"] = []string{`C:\ProgramData\New Relic\.NET Agent\newrelic.config`, `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`}
+					invalidLKToSources["eu01xx66c637a29c3982469a3fe8d1982d00NRAL"] = []string{`C:\ProgramData\New Relic\.NET Agent\newrelic.config`, `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml`}
 					return map[string][]string{}, invalidLKToSources, nil
 				}
 			})
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-        Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in C:\ProgramData\New Relic\.NET Agent\newrelic.config,` + "\n " + `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml` + " did not pass our validation check when verifying against your account:\neu01xx66c637a29c3982469a3fe8d1982d00NRAL\nIf your agent is reporting an 'Invalid license key' log entry, please reach out to New Relic Support.\n\n"))
-
+				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in C:\ProgramData\New Relic\.NET Agent\newrelic.config,` + "\n " + `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml` + " did not pass our validation check when verifying against your account:\neu01xx66c637a29c3982469a3fe8d1982d00NRAL\nIf your agent is reporting an 'Invalid license key' log entry, please reach out to New Relic Support.\n\n"))
 
 			})
 		})
@@ -182,7 +179,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal("We validated 2 license key(s):\n" + `The license key found in /newrelic/newrelic.yml passed our validation check when verifying against your account:` + "\n" + ` 08a2ad66c637a29c3982469a3fe8d1982d002c4a` + "\n" + "Note: If your agent is reporting an 'Invalid license key' log entry for this valid License key, reach out to New Relic support to verify any issues in our end.\n" + "\n" + `The license key found in` + "\n" + ` C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml ` + "\n" + `does not have a valid format: 08a2ad66c637a29c3982469a3fe8d1982d002c4. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
+				Expect(result.Summary).To(Equal("We validated 2 license key(s):\n" + `The license key found in /newrelic/newrelic.yml passed our validation check when verifying against your account:` + "\n" + ` 08a2ad66c637a29c3982469a3fe8d1982d002c4a` + "\n" + "Note: If your agent is reporting an 'Invalid license key' log entry for this valid License key, reach out to New Relic support to verify any issues in our end.\n" + "\n" + `The license key found in C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml does not have a valid format: 08a2ad66c637a29c3982469a3fe8d1982d002c4. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
 			})
 		})
 
@@ -261,7 +258,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 						Status: tasks.Success,
 						Payload: []LicenseKey{
 							LicenseKey{
-                Value:  `"aaaaaa1a1a11a111111aa1111a11aa1a11aa111aaaa1a11"`,
+								Value:  `"aaaaaa1a1a11a111111aa1111a11aa1a11aa111aaaa1a11"`,
 								Source: "mynodeapp/newrelic.js",
 							},
 						},
@@ -271,8 +268,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-        Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in` + "\n" + ` mynodeapp/newrelic.js ` + "\n" + `does not have a valid format: aaaaaa1a1a11a111111aa1111a11aa1a11aa111aaaa1a11. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
-
+				Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in mynodeapp/newrelic.js does not have a valid format: aaaaaa1a1a11a111111aa1111a11aa1a11aa111aaaa1a11. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
 
 			})
 		})
@@ -295,7 +291,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in` + "\n" + ` newrelic/newrelic.yml ` + "\n" + `does not have a valid format: <%!=(MISSING)c8f8ff84ed677d5791eeefb672a69447fb788486%!>(MISSING). ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
+				Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in newrelic/newrelic.yml does not have a valid format: <%!=(MISSING)c8f8ff84ed677d5791eeefb672a69447fb788486%!>(MISSING). ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
 
 			})
 		})
@@ -319,7 +315,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in` + "\n" + ` C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml ` + "\n" + `does not have a valid format: 5306276ad40fb0c3caccba85f869dcadc018e54. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
+				Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml does not have a valid format: 5306276ad40fb0c3caccba85f869dcadc018e54. ` + "\n" + `The NR license key is 40 alphanumeric characters. ` + "\n" + `Review this documentation to make sure that you have the proper format of a New Relic Personal API key: ` + "\n" + `https://docs.newrelic.com/docs/apis/get-started/intro-apis/types-new-relic-api-keys` + "\n\n"))
 
 			})
 		})
@@ -338,7 +334,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 								Source: "newrelic/newrelic.yml",
 							},
 							LicenseKey{
-                Value:  `eu01xx66c637a29c3982469a3fe8d1982d00NRAL`,
+								Value:  `eu01xx66c637a29c3982469a3fe8d1982d00NRAL`,
 								Source: "NEW_RELIC_LICENSE_KEY",
 							},
 						},
@@ -346,14 +342,13 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 				}
 				p.validateAgainstAccount = func(map[string][]string) (map[string][]string, map[string][]string, error) {
 					validLKToSources := make(map[string][]string)
-          validLKToSources["eu01xx66c637a29c3982469a3fe8d1982d00NRAL"] = []string{"NEW_RELIC_LICENSE_KEY"}
+					validLKToSources["eu01xx66c637a29c3982469a3fe8d1982d00NRAL"] = []string{"NEW_RELIC_LICENSE_KEY"}
 					return validLKToSources, map[string][]string{}, nil
 				}
 			})
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Success))
-        Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in NEW_RELIC_LICENSE_KEY passed our validation check when verifying against your account:` + "\n" + ` eu01xx66c637a29c3982469a3fe8d1982d00NRAL` + "\n" + `Note: If your agent is reporting an 'Invalid license key' log entry for this valid License key, please verify that your agent version is compatible with New Relic license keys that are 'region aware': https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers. Reach out to Support if this is not the issue.` + "\n"))
-
+				Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in NEW_RELIC_LICENSE_KEY passed our validation check when verifying against your account:` + "\n" + ` eu01xx66c637a29c3982469a3fe8d1982d00NRAL` + "\n" + `Note: If your agent is reporting an 'Invalid license key' log entry for this valid License key, please verify that your agent version is compatible with New Relic license keys that are 'region aware': https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers. Reach out to Support if this is not the issue.` + "\n"))
 
 			})
 
@@ -366,7 +361,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 						Status: tasks.Success,
 						Payload: []LicenseKey{
 							LicenseKey{
-                Value:  `eu01xx66c637a29c3982469a3fe8d1982d00NRAL`,
+								Value:  `eu01xx66c637a29c3982469a3fe8d1982d00NRAL`,
 								Source: "NRIA_LICENSE_KEY",
 							},
 							LicenseKey{
@@ -378,15 +373,14 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 				}
 				p.validateAgainstAccount = func(map[string][]string) (map[string][]string, map[string][]string, error) {
 					validLKToSources := make(map[string][]string)
-          validLKToSources["eu01xx66c637a29c3982469a3fe8d1982d00NRAL"] = []string{"NRIA_LICENSE_KEY"}
+					validLKToSources["eu01xx66c637a29c3982469a3fe8d1982d00NRAL"] = []string{"NRIA_LICENSE_KEY"}
 					return validLKToSources, map[string][]string{}, nil
 				}
 			})
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Success))
-        Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in NRIA_LICENSE_KEY passed our validation check when verifying against your account:` + "\n" + ` eu01xx66c637a29c3982469a3fe8d1982d00NRAL` + "\n" + `Note: If your agent is reporting an 'Invalid license key' log entry for this valid License key, please verify that your agent version is compatible with New Relic license keys that are 'region aware': https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers. Reach out to Support if this is not the issue.` + "\n"))
-
+				Expect(result.Summary).To(Equal("We validated 1 license key(s):\n" + `The license key found in NRIA_LICENSE_KEY passed our validation check when verifying against your account:` + "\n" + ` eu01xx66c637a29c3982469a3fe8d1982d00NRAL` + "\n" + `Note: If your agent is reporting an 'Invalid license key' log entry for this valid License key, please verify that your agent version is compatible with New Relic license keys that are 'region aware': https://docs.newrelic.com/docs/using-new-relic/welcome-new-relic/get-started/our-eu-us-region-data-centers. Reach out to Support if this is not the issue.` + "\n"))
 
 			})
 		})

--- a/tasks/base/env/collectSysProps.go
+++ b/tasks/base/env/collectSysProps.go
@@ -1,0 +1,43 @@
+package env
+
+import (
+	"fmt"
+
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+// BaseEnvCollectSysProps - This struct defined the sample plugin which can be used as a starting point
+type BaseEnvCollectSysProps struct {
+}
+
+// Identifier - This returns the Category, Subcategory and Name of each task
+func (t BaseEnvCollectSysProps) Identifier() tasks.Identifier {
+	return tasks.IdentifierFromString("Base/Env/CollectSysProps")
+}
+
+// Explain - Returns the help text for each individual task
+func (t BaseEnvCollectSysProps) Explain() string {
+	return "Collect new relic system properties for running JVM processes"
+}
+
+// Dependencies - Returns the dependencies for ech task.
+func (t BaseEnvCollectSysProps) Dependencies() []string {
+	return []string{}
+}
+
+// Execute - The core work within each task
+func (t BaseEnvCollectSysProps) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
+	systemProps := tasks.GetNewRelicSystemProps()
+	fmt.Println("luces slice of structs: ", systemProps)
+	if len(systemProps) > 0 {
+		return tasks.Result{
+			Status:  tasks.Info,
+			Summary: "Succesfully collected some new relic system properties",
+			Payload: systemProps,//[]ProcIDSysProps
+		}
+	}
+	return tasks.Result{
+		Status:  tasks.None,
+		Summary: "No new relic system properties were found",
+	}
+}

--- a/tasks/base/env/collectSysProps.go
+++ b/tasks/base/env/collectSysProps.go
@@ -1,8 +1,6 @@
 package env
 
 import (
-	"fmt"
-
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
@@ -28,12 +26,12 @@ func (t BaseEnvCollectSysProps) Dependencies() []string {
 // Execute - The core work within each task
 func (t BaseEnvCollectSysProps) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
 	systemProps := tasks.GetNewRelicSystemProps()
-	fmt.Println("luces slice of structs: ", systemProps)
+
 	if len(systemProps) > 0 {
 		return tasks.Result{
 			Status:  tasks.Info,
 			Summary: "Succesfully collected some new relic system properties",
-			Payload: systemProps,//[]ProcIDSysProps
+			Payload: systemProps, //[]ProcIDSysProps
 		}
 	}
 	return tasks.Result{

--- a/tasks/base/env/env.go
+++ b/tasks/base/env/env.go
@@ -17,6 +17,7 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		HostInfoProviderWithContext: NewHostInfoWithContext,
 	}, true)
 	registrationFunc(BaseEnvCollectEnvVars{}, true)
+	registrationFunc(BaseEnvCollectSysProps{}, true)
 	registrationFunc(BaseEnvDetectAWS{
 		httpGetter: tasks.HTTPRequester,
 	}, true)

--- a/tasks/base/log/logHelpers.go
+++ b/tasks/base/log/logHelpers.go
@@ -25,7 +25,7 @@ var secureLogFilenamePatterns = []string{"docker[.]log$",
 	"syslog$",
 }
 
-var logSysProp = "-Dnewrelic.log" //EX: Dnewrelic.logfile=/opt/newrelic/java/logs/newrelic/somenewnameformylogs.log
+var logSysProp = "-Dnewrelic.logfile" //EX: Dnewrelic.logfile=/opt/newrelic/java/logs/newrelic/somenewnameformylogs.log
 
 var logEnvVars = []string{
 	"NRIA_LOG_FILE", // Infra agent
@@ -126,15 +126,17 @@ func collectFilePaths(envVars map[string]string, configElements []baseConfig.Val
 		}
 	}
 
-	//this is our fallback because env vars and default paths should take precedence over system properties and config files
-	if len(fileLocations) < 1 && len(secureFileLocations) < 1 {
-		//check for potential system property set
-		if len(foundSysPropPath) > 0 &&
-		!(tasks.PosString(fileLocations, foundSysPropPath) > -1) && //make sure we are not adding a log file we already found
-		!(tasks.PosString(secureFileLocations, foundSysPropPath) > -1) {
+	//check for system properties
+	if len(foundSysPropPath) > 0 {
+		//make sure we are not adding a log file we already found
+		if !(tasks.PosString(fileLocations, foundSysPropPath) > -1) && !(tasks.PosString(secureFileLocations, foundSysPropPath) > -1) {
 			fileLocations = append(fileLocations, foundSysPropPath)
 		}
-		//even if we found a path through system prop, we still want to check config files in case we are looking at an app that has, say, Infra agent besides Java agent
+
+	}
+
+	//this is our fallback because env vars, system props and default paths can take precedence over config files values
+	if len(fileLocations) < 1 && len(secureFileLocations) < 1 {
 		configFilePaths := getLogPathsFromConfigFile(configElements)
 		fileLocations = append(fileLocations, configFilePaths...)
 	}


### PR DESCRIPTION
# Issue

We have tasks that look into config file settings and environment variables to validate if a customer's configuration has been appropriately implemented, for example, Base/Config/AppName, Base/Config/ValidateLicenseKey, and Base/Config/ValidateHSM. The issue is that these tasks would possibly give a false positive result if the configuration has applied through JVM System Properties (in the case of the Java agent) because we do not collect and look at system properties yet, only env vars and settings in config files. 

# Goals

1.Add a task for collecting system properties: Base/Env/CollectSysProps

2.Use the upstream payload from Base/Env/CollectSysProps in tasks that validate Java Agent configuration settings. Those tasks are:

Base/Config/Collect
Base/Config/AppName
Base/Config/LicenseKey
Base/Log/Loghelpers
Base/Log/Copy

I was going to include our high-security validation task (Base/Config/ValidateHSM) in this list but while checking in docs, tickets, slack, and consulting with a TSE, it doesn't seem that `-Dnewrelic.config.high_security` is used among customers. Is either deprecated or is not used much in comparison to the env var or config file options for high-security mode. That's why I deprioritize implementing system property into this task.

# Implementation Details

Before you go into reviewing the "Files changed" section/tab above(which does not display the changes in chronological order), I recommend starting to review the implementations in the following order:
1.CollectSysProps.go : 
https://github.com/newrelic/newrelic-diagnostics-cli/blob/b4b1e1bec24b6aac4935adb54a2298161705e038/tasks/base/env/collectSysProps.go

2.TasksHelpers.go: 
https://github.com/newrelic/newrelic-diagnostics-cli/blob/b4b1e1bec24b6aac4935adb54a2298161705e038/tasks/taskHelpers.go#L772

3.Any of the tasks that were modified within this path: tasks/base/config/
The order does not matter. You can skip reviewing the _test.go files if you wish, but it may be worth just to take a quick peek, so you get an idea of what I expect the behavior of the task to be after my changes

# How to Test

Most of the tasks where I have implemented changes to validate for system properties, already have a bunch of units test that should confirm that expected behavior after those changes. Please check those unit tests as they are very thorough and document really well what I expect those changes to accomplish.
On the other hand, there are a couple of tasks that do not have a file for unit tests yet (and I am not adding that file at least for this PR or MMF story), so if you can smoke test those couple of tasks (Base/Config/Collect and Base/Log/Copy) by running them in a real Java app environment that sets `-Dnewrelic.config.file` and `-Dnewrelic.log`, that'd be a great test! I have smoke test them myself in darwin but is always nice to try it out in different environments (Linux or windows). 

This is the way you can smoke test in your environment:
-First, clone this repo and then check-in into this specific branch (`git checkout collectSysProps`)
-Then you can run `go build`, or you can run `./scripts/build.sh`, which will build the binary for all operating systems.
-`go build` will build the binary `newrelic-diagnostics-cli` in the current work directory. But `./scripts/build.sh` will build the binaries inside of  a bin/ directory.
-Now you can bring your binary and drop it into your java app directory. You can either run all java tasks with `./newrelic-diagnostics-cli -y -suites java` 
Or you can target the specific task by running `./newrelic-diagnostics-cli -t Base/Config/Collect`

Note: the `-y` option is for saying yes to all prompts nrdiag will ask before collecting a file (security reasons) 