### PR TITLE
Updated tool naming to be consistent

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-           - 1.13.x
-          #  - 1.14.x
+          #  - 1.13.x
+           - 1.14.x
         platform:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          #  - 1.13.x
-           - 1.14.x
+           - 1.13.x
+          #  - 1.14.x
         platform:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  # NR Diag binaries must compile on all of our supported OSes
+  # nrdiag binaries must compile on all of our supported OSes
   compile:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 [![Community Project header](https://github.com/newrelic/opensource-website/raw/master/src/images/categories/Community_Project.png)](https://opensource.newrelic.com/oss-category/#community-project)
 
-# NR Diag
+# Diagnostics CLI (nrdiag)
 
-NR Diag was built, and is maintained, by New Relic Global Technical Support.
+The Diagnostics CLI was built, and is maintained, by New Relic Global Technical Support.
 It is a diagnostic and troubleshooting tool used to find common issues with New Relic Supported Products and Projects. Great for apps not reporting data to New Relic. Issues with connectivity, [configuration](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#h2-validate-your-config-file-settings), and compatibility. If it finds an issue it will suggest resolutions and relevant documentation. If it can’t help you resolve the issue, the information it gathers will help when troubleshooting with New Relic Support.
 
 ## Installation
 
-**NR Diag supports Linux, macOS, and Windows.**
+**Diagnostics CLI  supports Linux, macOS, and Windows.**
 
 To install in a Docker container see [here](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#h2-run-new-relic-diagnostics-in-a-docker-container)
 
@@ -18,30 +18,30 @@ To install in a Docker container see [here](https://docs.newrelic.com/docs/using
 
 
 ## Usage
-NR Diag can help you troubleshoot issues and confirm that everything is working as expected. If after running NR Diag you think you are still having issues review [Global Technical Support options](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings) that may be available for your issue, NR Diag output can help us resolve issues faster so keep it around!
+The Diagnostics CLI can help you troubleshoot issues and confirm that everything is working as expected. If after running the Diagnostics CLI you think you are still having issues review [Global Technical Support options](https://docs.newrelic.com/docs/licenses/license-information/general-usage-licenses/global-technical-support-offerings) that may be available for your issue, the Diagnostics CLI output can help us resolve issues faster so keep it around!
 *Optional, but highly recommended*: Temporarily raise the logging level for the New Relic agent for more complete troubleshooting. Instructions can be found in [this documentation](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/generate-new-relic-agent-logs-troubleshooting)
 
  ### Troubleshooting and Diagnostics
  1. Open an elevated command prompt
- 2. Navigate to root directory of your application (or where ever you placed the NR Diag binary)
+ 2. Navigate to root directory of your application (or where ever you placed the binary `nrdiag`)
  3. Run `nrdiag`
    * Target functionality by using cmd line args such as [suites to target specific products or issues](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#task-suites) or see [all cmd line argos](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#cli-options)
 4. Review results( [tips on interpreting output](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#interpret-output)).
 
 ### Working with Global Technical Support
-If after running NR Diag, reviewing the output, and attempting to resolve the issue you are still having difficulties understanding what the issue is, the data gathered by NR Diag can be used by Global Technical Support to help resolve the issue, often in quicker time then without the data. Note if you have fixed any issues called out by NR Diag, either rerun it or let us know what you tried or changed (up to date results ensure more accurate troubleshooting)
-If you have or are going to open a ticket with Global Technical Support, then [uploading the data gathered](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#attach-ticket-results) by NR Diag will as early as possible will speed up the troubleshooting process.
-To upload your results automatically to a New Relic Support ticket all you need to do is run nrdiag binary using the attachment flag `-a MY-ATTACHMENT-KEY` You can get your attachment key by viewing the ticket in the New Relic Support Portal. You can also request a support engineer to provide you the attachment key.
+If after running the Diagnostics CLI, reviewing the output, and attempting to resolve the issue you are still having difficulties understanding what the issue is, the data gathered by the Diagnostics CLI can be used by Global Technical Support to help resolve the issue, often in quicker time then without the data. Note if you have fixed any issues called out by the Diagnostics CLI, either rerun it or let us know what you tried or changed (up to date results ensure more accurate troubleshooting)
+If you have or are going to open a ticket with Global Technical Support, then [uploading the data gathered](https://docs.newrelic.com/docs/using-new-relic/cross-product-functions/troubleshooting/new-relic-diagnostics#attach-ticket-results) by the Diagnostics CLI will as early as possible will speed up the troubleshooting process.
+To upload your results automatically to a New Relic Support ticket all you need to do is run `nrdiag` binary using the attachment flag `-a MY-ATTACHMENT-KEY` You can get your attachment key by viewing the ticket in the New Relic Support Portal. You can also request a support engineer to provide you the attachment key.
 
 
 
-## Support for NR Diag
+## Support for the Diagnostics CLI
 
-New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. Like all official New Relic open source projects, there's a related Community topic in the New Relic Explorers Hub. If you have any questions, concerns or issues while running NR Diag, reach out to us through our [Explorers Hub](https://discuss.newrelic.com/t/new-relic-diagnostic-aka-nr-diag/118819). Or if the issue has been confirmed as a bug or is a Feature request, please file a Github issue. Either way we'll get back to you soon!
+New Relic hosts and moderates an online forum where customers can interact with New Relic employees as well as other customers to get help and share best practices. Like all official New Relic open source projects, there's a related Community topic in the New Relic Explorers Hub. If you have any questions, concerns or issues while running the Diagnostics CLI, reach out to us through our [Explorers Hub](https://discuss.newrelic.com/t/new-relic-diagnostic-aka-nr-diag/118819). Or if the issue has been confirmed as a bug or is a Feature request, please file a Github issue. Either way we'll get back to you soon!
 
 ## Contributing
-Have you ever dealt with a New Relic installation and/or configuration issue? Do you have suggestions on how to automate those steps to diagnose and solve the issue? Then we would love for you to contribute to NR Diag (or at least file a very detailed feature request)! NR Diag's main goal is to speed up and simplify the resolution of issues, no matter if you are working on your own or with our Support teams.
-All the information on how to build a new health check using NR Diag, as well as the requirements to submit a PR, can be found in our docs directory. Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
+Have you ever dealt with a New Relic installation and/or configuration issue? Do you have suggestions on how to automate those steps to diagnose and solve the issue? Then we would love for you to contribute to the Diagnostics CLI (or at least file a very detailed feature request)! The Diagnostics CLI's main goal is to speed up and simplify the resolution of issues, no matter if you are working on your own or with our Support teams.
+All the information on how to build a new health check using the Diagnostics CLI, as well as the requirements to submit a PR, can be found in our docs directory. Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project.
 
 Aditionally, you'll have to fork this repo prior to cloning or you'll get a permissions error.
 
@@ -59,5 +59,5 @@ If you have any questions, or to execute our corporate CLA, required if your con
 
 
 ## License
-[NR Diag] is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
->[[NR Diag] also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.]
+The Diagnostics CLI is licensed under the [Apache 2.0](http://apache.org/licenses/LICENSE-2.0.txt) License.
+>[The Diagnostics CLI also uses source code from third-party libraries. You can find full details on which libraries are used and the terms under which they are licensed in the third-party notices document.]

--- a/config/config.go
+++ b/config/config.go
@@ -181,7 +181,7 @@ func ParseFlags() {
 	// Bail early if bad length attachment key provided.
 	if Flags.AttachmentKey != "" && len(Flags.AttachmentKey) < 32 {
 		fmt.Printf("Invalid attachment key '%s' length: %d\n", Flags.AttachmentKey, len(Flags.AttachmentKey))
-		fmt.Println("The 32 character NR Diagnostics Attachment Key can be found upper-right of your ticket on support.newrelic.com")
+		fmt.Println("The 32 character Diagnostics CLI Attachment Key can be found upper-right of your ticket on support.newrelic.com")
 		os.Exit(1)
 	}
 

--- a/docs/Anatomy-of-a-Task.md
+++ b/docs/Anatomy-of-a-Task.md
@@ -60,7 +60,7 @@ The registration file to add your task to this package would be:
 tasks/morty/agent/agent.go
 ```
 
-This is where you register the task(s) for the Morty agent, so that they can be used and run by NR Diag core. Just add a...
+This is where you register the task(s) for the Morty agent, so that they can be used and run by the Diagnostics CLI core. Just add a...
 
 ```
 registrationFunc(MortyAgentTaskname{}, true)

--- a/docs/Coding-Guidelines.md
+++ b/docs/Coding-Guidelines.md
@@ -8,7 +8,7 @@
 * Code readability and maintainability is top priority. 
   * Don’t be clever.
   * Don’t sacrifice readability to DRY up code.
-  * Consistent naming is important, if you want to include the name of this tool in a tasks output use const `ThisProgramFullName`   
+  * Consistent naming is important, if you want to include the name of this tool in a tasks output use const `tasks.ThisProgramFullName`   
 * Your code will be running on the customer’s machine.
   * Be sensitive to your code’s memory footprint (e.g. don’t load large files into memory).
   * Don’t perform blocking operations for long periods of time.

--- a/docs/Coding-Guidelines.md
+++ b/docs/Coding-Guidelines.md
@@ -8,6 +8,7 @@
 * Code readability and maintainability is top priority. 
   * Don’t be clever.
   * Don’t sacrifice readability to DRY up code.
+  * Consistent naming is important, if you want to include the name of this tool in a tasks output use const `ThisProgramFullName`   
 * Your code will be running on the customer’s machine.
   * Be sensitive to your code’s memory footprint (e.g. don’t load large files into memory).
   * Don’t perform blocking operations for long periods of time.

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -41,7 +41,7 @@ We host a public Slack with a dedicated channel for contributors and maintainers
 
 ### Guidance
 
-If you have an idea for a new health check or any additional steps nrdiag should take to validate that a New Relic product has been configured correctly, then you should build a task for the Diagnostics CLI, it's easy!
+If you have an idea for a new health check or any additional steps the Diagnostics CLI should take to validate that a New Relic product has been configured correctly, then you should build a task for the Diagnostics CLI, it's easy!
 
 All the docs provided in this directory are meant to guide you through how to build a task for the Diagnostics CLI and how to write appropriate tests for the task. Those docs are very thorough, and were written considering contributors of all levels of technical knowledge.
 
@@ -49,7 +49,7 @@ Besides the documentation itself, you can take a look at the files within the ta
 
 One important thing to keep in mind is that we have already written a lot of good, basic health checks. Please make sure that your idea for a health check has not yet been implemented in one way or another in our tasks directory. If you do not find it and you are ready to start building your task, then take advantage of the helper functions provided in our taskHelpers files inside the tasks directory. This is boiler plate logic that we found is applicable and useful to most New Relic health checks.
 
-Additionally, take advantage of other Diagnostics CLI tasks to build your own task on top of them. Imagine you want to build a task to validate that a customer is using only Node.js supported versions for the Node Agent, then you could use another nrdiag task that already gathers the Node version from customer's environment. To get more details on how take advantage of `upstream` tasks, take a look at the [code snippets in our Coding Guidelines.](https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/docs/Coding-Guidelines.md)
+Additionally, take advantage of other Diagnostics CLI tasks to build your own task on top of them. Imagine you want to build a task to validate that a customer is using only Node.js supported versions for the Node Agent, then you could use another Diagnostics CLI task that already gathers the Node version from customer's environment. To get more details on how take advantage of `upstream` tasks, take a look at the [code snippets in our Coding Guidelines.](https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/docs/Coding-Guidelines.md)
 
 
 ### Testing your task

--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -29,7 +29,7 @@ For more information about CLAs, please check out Alex Russell’s excellent pos
 
 We host a public Slack with a dedicated channel for contributors and maintainers of open source projects hosted by New Relic.  If you are contributing to this project, you're welcome to request access to the #oss-contributors channel in the newrelicusers.slack.com workspace.  To request access, see https://newrelicusers-signup.herokuapp.com/.
 
-## Developing for NR diag
+## Developing for the Diagnostics CLI
 
 ### Requirements
 
@@ -41,15 +41,15 @@ We host a public Slack with a dedicated channel for contributors and maintainers
 
 ### Guidance
 
-If you have an idea for a new health check or any additional steps nrdiag should take to validate that a New Relic product has been configured correctly, then you should build an NR Diag task, it's easy!
+If you have an idea for a new health check or any additional steps nrdiag should take to validate that a New Relic product has been configured correctly, then you should build a task for the Diagnostics CLI, it's easy!
 
-All the docs provided in this directory are meant to guide you through how to build an NR Diag task and how to write appropriate tests for it. Those docs are very thorough, and were written considering contributors of all levels of technical knowledge.
+All the docs provided in this directory are meant to guide you through how to build a task for the Diagnostics CLI and how to write appropriate tests for the task. Those docs are very thorough, and were written considering contributors of all levels of technical knowledge.
 
-Besides the documentation itself, you can take a look at the files within the task directory, and soon you'll notice that each NR Diag task has a very clear pattern and structure that you can use as reference to build your own task.
+Besides the documentation itself, you can take a look at the files within the task directory, and soon you'll notice that each task in the Diagnostics CLI has a very clear pattern and structure that you can use as reference to build your own task.
 
 One important thing to keep in mind is that we have already written a lot of good, basic health checks. Please make sure that your idea for a health check has not yet been implemented in one way or another in our tasks directory. If you do not find it and you are ready to start building your task, then take advantage of the helper functions provided in our taskHelpers files inside the tasks directory. This is boiler plate logic that we found is applicable and useful to most New Relic health checks.
 
-Additionally, take advantage of other NR diag tasks to build your own task on top of them. Imagine you want to build a task to validate that a customer is using only Node.js supported versions for the Node Agent, then you could use another nrdiag task that already gathers the Node version from customer's environment. To get more details on how take advantage of `upstream` tasks, take a look at the [code snippets in our Coding Guidelines.](https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/docs/Coding-Guidelines.md)
+Additionally, take advantage of other Diagnostics CLI tasks to build your own task on top of them. Imagine you want to build a task to validate that a customer is using only Node.js supported versions for the Node Agent, then you could use another nrdiag task that already gathers the Node version from customer's environment. To get more details on how take advantage of `upstream` tasks, take a look at the [code snippets in our Coding Guidelines.](https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/docs/Coding-Guidelines.md)
 
 
 ### Testing your task

--- a/docs/Dependency-Injection.md
+++ b/docs/Dependency-Injection.md
@@ -59,7 +59,7 @@ Let's refactor `makeCollectorRequest()`. To do so, we need to:
 
 1. Add a field to the task struct for each of our external depencies. 
 2. Attach our `makeCollectorRequest()` function to the task struct as a struct method (so it can reference its dependencies defined as struct fields)
-3. Define our "in-production" dependency when registering our task with the NR Diag task runner, i.e. creating the task struct instance.
+3. Define our "in-production" dependency when registering our task with the Diagnostics CLI task runner, i.e. creating the task struct instance.
 
 ### (1) allow dependencies to be attached to the task struct as struct fields
 

--- a/docs/How-To-Build-A-Task.md
+++ b/docs/How-To-Build-A-Task.md
@@ -38,7 +38,7 @@ We've got a file, but it still has all the original example names
 
 ### Register the new task
 
-Now we have a task that doesn't do much, but we should at least be able to compile and run it. However, NR Diag doesn't know that it's *supposed* to run this task yet. So, we have to "register" the new task (note: this registration step is unique to this project; it's not a normal `go` thing).
+Now we have a task that doesn't do much, but we should at least be able to compile and run it. However, the Diagnostics CLI doesn't know that it's *supposed* to run this task yet. So, we have to "register" the new task (note: this registration step is unique to this project; it's not a normal `go` thing).
 
 Find the "main" package file for the package/folder your task is in. In our case, this is going to be the file `./tasks/java/jvm/jvm.go`
 

--- a/docs/Integration-Testing.md
+++ b/docs/Integration-Testing.md
@@ -9,7 +9,7 @@ If you believe you've encountered a case in which integration tests are necessar
 
 -------------------------------------------
 
-NR Diag has an integration test structure that allows us to programatically: 
+The Diagnostics CLI has an integration test structure that allows us to programmatically: 
 
 1. Build Dockerfiles from code 
 2. Build a docker image
@@ -79,7 +79,7 @@ All file references should be relative to the root of the project.
 
 - docker_cmd - adds a custom docker CMD command, wrapped in a shell command to execute the desired actions
 
-**Example:** runs NR Diag with a proxy
+**Example:** runs the Diagnostics CLI with a proxy
 
 ```yml
  -  test_name: ProxyConnect
@@ -95,7 +95,7 @@ All file references should be relative to the root of the project.
 
 - docker_from - Adds a custom docker FROM command to change the source image the docker container is built from. The integration test suite will automatically add the nrdiag binary and set the work directory to /app when using a custom image source.
 
-**Example:** run NR Diag from an ubuntu image
+**Example:** run the Diagnostics CLI from an ubuntu image
 
 ```yml
  -  test_name: ProxyConnect
@@ -167,6 +167,6 @@ These can be combined into a single command for convenience with
 
 `docker build --rm -t myTest -f integrationDockerfile && docker run --rm myTest`. 
 
-#### Running NR Diag with options
+#### Running the Diagnostics CLI with options
 It's worth noting that while the default integration dockerfile does add `CMD ["./nrdiag"]` to run nrdiag without verbose mode, you can run verbose mode by just adding a `CMD ["./nrdiag", "-v"]` to run nrdiag with verbose or some other series of options and it will be executed instead of the default nrdiag execution because it will appear after the first entry of CMD.
 

--- a/docs/Release-Runbook.md
+++ b/docs/Release-Runbook.md
@@ -1,4 +1,4 @@
-# Diagnostics CLIrelease runbook - Internal usage only
+# Diagnostics CLI release runbook - Internal usage only
 
 This assumes the main branch is in a state ready for release. 
 

--- a/docs/Release-Runbook.md
+++ b/docs/Release-Runbook.md
@@ -1,4 +1,4 @@
-# NR Diag release runbook - Internal usage only
+# Diagnostics CLIrelease runbook - Internal usage only
 
 This assumes the main branch is in a state ready for release. 
 

--- a/docs/Testing-Overview.md
+++ b/docs/Testing-Overview.md
@@ -1,6 +1,6 @@
 # Testing
 
-NR Diag utilizes two types of testing: [Unit testing](Unit-Testing.md) and [Integration testing](Integration-Testing.md).
+The Diagnostics CLI utilizes two types of testing: [Unit testing](Unit-Testing.md) and [Integration testing](Integration-Testing.md).
 
 We recommend **unit testing** to make up a majority of your code's test coverage because unit tests:
  * Are quicker to run than integration tests
@@ -10,7 +10,7 @@ We recommend **unit testing** to make up a majority of your code's test coverage
 
  If you believe you are unable to use unit tests to adequately test your code, please add your reasoning for not using unit tests.
  
-Here is our documentation on both unit and integration testing your NR Diag contributions:
+Here is our documentation on both unit and integration testing your Diagnostics CLI contributions:
 
 * [**Unit testing**](Unit-Testing.md)
 * [**Integration testing**](Integration-Testing.md)

--- a/docs/Unit-Testing.md
+++ b/docs/Unit-Testing.md
@@ -4,7 +4,7 @@ _This image will make sense in about 5 minutes._
 
 # Unit Tests
 
-We require contributors to provide unit test coverage for submitted NR Diag tasks. Test-driven Development (TDD) is one of the best ways introduce test coverage while writing readable, maintainable, and high quality code.
+We require contributors to provide unit test coverage for submitted Diagnostics CLI tasks. Test-driven Development (TDD) is one of the best ways introduce test coverage while writing readable, maintainable, and high quality code.
 
 It is recommended you plan out your task to use separate methods that are then invoked in your task's `Execute()` method. 
 You can then write unit tests for each of those individual methods. 
@@ -32,7 +32,7 @@ You should read the following article before moving forward with this readme:
 
 # Getting setup with Ginkgo
 
-[Ginkgo](http://onsi.github.io/ginkgo/) is the Go testing framework we use for unit testing in NR Diag. We'll be using it to write unit tests in this tutorial.
+[Ginkgo](http://onsi.github.io/ginkgo/) is the Go testing framework we use for unit testing in the Diagnostics CLI. We'll be using it to write unit tests in this tutorial.
 
 You can install Ginkgo by running the following commands in your terminal:
 
@@ -378,7 +378,7 @@ If you would like to check your work and see the finished task and task_test fil
 * [Completed `count.go`](../tasks/example/docs/completed_count.go)
 * [Completed `count_test.go`](../tasks/example/docs/completed_count_test.go)
 
-> **NOTE:** You may notice `[]LogElement{}` is changed to `[]log.LogElement{}` in the above two files. In order to avoid this example task being a part of NR Diag itself,  the two example files live in the `tasks/example/docs/` folder and are thus part of the `docs` package, instead of the `log` package.
+> **NOTE:** You may notice `[]LogElement{}` is changed to `[]log.LogElement{}` in the above two files. In order to avoid this example task being a part of the Diagnostics CLI itself,  the two example files live in the `tasks/example/docs/` folder and are thus part of the `docs` package, instead of the `log` package.
 
 # Dependency injection
 
@@ -386,4 +386,4 @@ Dependency injection helps us write more testable code by passing in external de
 
 Using dependency injection is especially useful when writing unit tests for your task's `Execute()` function.
 
-For an example of how you can use this in NR Diag, see the [Dependency Injection readme](Dependency-Injection.md)
+For an example of how you can use this in the Diagnostics CLI, see the [Dependency Injection readme](Dependency-Injection.md)

--- a/integration_test_timer.go
+++ b/integration_test_timer.go
@@ -1,4 +1,4 @@
-// Class defines structs and methods for timing the run of NR Diag integration tests, and sending test result/timing data to Insights.
+// Class defines structs and methods for timing the run of the Diagnostics CLI integration tests, and sending test result/timing data to Insights.
 // This expects INSIGHTS_API_KEY and INSIGHTS_ACCOUNT_ID environment variables to be set, otherwise it skips
 // uploading to Insights.
 package main

--- a/internal/haberdasher/haberdasher.go
+++ b/internal/haberdasher/haberdasher.go
@@ -34,7 +34,7 @@ type Client struct {
 	// User Agent used when communication with Haberdasher API
 	UserAgent string
 
-	// RunID is unique to each run of NR Diag and is required as a header for many haberdasher endpoints
+	// RunID is unique to each run of the Diagnostics CLI and is required as a header for many haberdasher endpoints
 	RunID string
 
 	// InsertKey is a value seeded by the RunID, and is required as a header for many haberdasher endpoints
@@ -171,7 +171,7 @@ func newResponse(r *http.Response) *Response {
 	return response
 }
 
-// SetRunID sets the NR Diag run ID for a client
+// SetRunID sets the Diagnostics CLI run ID for a client
 func (c *Client) SetRunID(runID string) {
 	c.RunID = runID
 	c.InsertKey = generateInsertKey(runID)

--- a/internal/haberdasher/tasks.go
+++ b/internal/haberdasher/tasks.go
@@ -1,4 +1,4 @@
 package haberdasher
 
-// TasksService is a service object containing methods used by individual nr diag tasks
+// TasksService is a service object containing methods used by individual Diagnostics CLI tasks
 type TasksService service

--- a/scripts/dependencyGrapher/generateGraph.py
+++ b/scripts/dependencyGrapher/generateGraph.py
@@ -1,5 +1,5 @@
 """
-This script takes csv formatted task dependency output from NR Diag
+This script takes csv formatted task dependency output from the Diagnostics CLI
 and creates a dependency graph using the graphviz library. 
 It expects a csv list from STDIN in the form: dependency, parent_task.
 This script is meant to be fed the output of `newrelic-diagnostics  --print-dependencies`

--- a/scripts/dependencyGrapher/main.go
+++ b/scripts/dependencyGrapher/main.go
@@ -41,7 +41,7 @@ func main() {
 
 }
 
-//parseTasks takes in slice of filepaths for nr diag tasks. It reads each file and parses out task identifier and dependencies
+//parseTasks takes in slice of filepaths for the Diagnostics CLI tasks. It reads each file and parses out task identifier and dependencies
 func parseTasks(goFiles []string) (map[string]map[string]bool, error) {
 	foundTasks := map[string]map[string]bool{}
 	for _, file := range goFiles {

--- a/tasks/base/config/collect.go
+++ b/tasks/base/config/collect.go
@@ -57,7 +57,7 @@ var secureFilePatterns = []string{
 	"(?i)appSettings[.]json$",
 }
 
-var warningSummaryFmt = "The " + ThisProgramFullName + " cannot collect New Relic config files from the provided path (%s):\n%s\nIf you are working with a support ticket, manually provide your New Relic config file for further troubleshooting\n"
+var warningSummaryFmt = "The " + tasks.ThisProgramFullName + " cannot collect New Relic config files from the provided path (%s):\n%s\nIf you are working with a support ticket, manually provide your New Relic config file for further troubleshooting\n"
 
 // BaseConfigCollect - Primary task to search for and find config file. Will optionally take command line input as source
 type BaseConfigCollect struct {
@@ -235,7 +235,7 @@ func (p BaseConfigCollect) Execute(options tasks.Options, upstream map[string]ta
 	if len(foundConfigs) == 0 && len(invalidConfigFiles) == 0 {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "New Relic configuration files not found where the " + ThisProgramFullName + " was executed. Please ensure the " + ThisProgramFullName + " executable is within your application's directory alongside your New Relic agent configuration file(s). If you cannot set New Relic configuration files in your application's directory, move the " + ThisProgramFullName + " to that directory or use the -c <file_path> to specify the New Relic configuration file location.",
+			Summary: "New Relic configuration files not found where the " + tasks.ThisProgramFullName + " was executed. Please ensure the " + tasks.ThisProgramFullName + " executable is within your application's directory alongside your New Relic agent configuration file(s). If you cannot set New Relic configuration files in your application's directory, move the " + tasks.ThisProgramFullName + " to that directory or use the -c <file_path> to specify the New Relic configuration file location.",
 		}
 	}
 

--- a/tasks/base/config/collect.go
+++ b/tasks/base/config/collect.go
@@ -57,7 +57,7 @@ var secureFilePatterns = []string{
 	"(?i)appSettings[.]json$",
 }
 
-var warningSummaryFmt = "NR Diagnostics cannot collect New Relic config files from the provided path (%s):\n%s\nIf you are working with a support ticket, manually provide your New Relic config file for further troubleshooting\n"
+var warningSummaryFmt = "The " + ThisProgramFullName + " cannot collect New Relic config files from the provided path (%s):\n%s\nIf you are working with a support ticket, manually provide your New Relic config file for further troubleshooting\n"
 
 // BaseConfigCollect - Primary task to search for and find config file. Will optionally take command line input as source
 type BaseConfigCollect struct {
@@ -235,7 +235,7 @@ func (p BaseConfigCollect) Execute(options tasks.Options, upstream map[string]ta
 	if len(foundConfigs) == 0 && len(invalidConfigFiles) == 0 {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "New Relic configuration files not found where NR Diagnostics was executed. Please ensure the NR Diagnostics executable is within your application's directory alongside your New Relic agent configuration file(s). If you cannot set New Relic configuration files in your application's directory, move NR Diagnostics to that directory or use the -c <file_path> to specify the New Relic configuration file location.",
+			Summary: "New Relic configuration files not found where the " + ThisProgramFullName + " was executed. Please ensure the " + ThisProgramFullName + " executable is within your application's directory alongside your New Relic agent configuration file(s). If you cannot set New Relic configuration files in your application's directory, move the " + ThisProgramFullName + " to that directory or use the -c <file_path> to specify the New Relic configuration file location.",
 		}
 	}
 

--- a/tasks/base/config/validateLicenseKey.go
+++ b/tasks/base/config/validateLicenseKey.go
@@ -139,7 +139,7 @@ func findLKFromEnvVarSources(licenseKeys []LicenseKey) []LicenseKey {
 
 func checkEnvVarFormat(licenseKey LicenseKey) (bool, string) {
 	if licenseKeyUsingQuotes(licenseKey.Value) {
-		errMsg := fmt.Sprintf(`Using quotes around %s may cause inconsistent behavior. We highly recommend removing those quotes, and running the ` + ThisProgramFullName + ` again.`+"\n\n", licenseKey.Source)
+		errMsg := fmt.Sprintf(`Using quotes around %s may cause inconsistent behavior. We highly recommend removing those quotes, and running the ` + tasks.ThisProgramFullName + ` again.`+"\n\n", licenseKey.Source)
 		return false, errMsg
 	}
 	if isFormatValid(strings.TrimSpace(licenseKey.Value)) {

--- a/tasks/base/config/validateLicenseKey.go
+++ b/tasks/base/config/validateLicenseKey.go
@@ -139,7 +139,7 @@ func findLKFromEnvVarSources(licenseKeys []LicenseKey) []LicenseKey {
 
 func checkEnvVarFormat(licenseKey LicenseKey) (bool, string) {
 	if licenseKeyUsingQuotes(licenseKey.Value) {
-		errMsg := fmt.Sprintf(`Using quotes around %s may cause inconsistent behavior. We highly recommend removing those quotes, and running NR Diagnostics again.`+"\n\n", licenseKey.Source)
+		errMsg := fmt.Sprintf(`Using quotes around %s may cause inconsistent behavior. We highly recommend removing those quotes, and running the ` + ThisProgramFullName + ` again.`+"\n\n", licenseKey.Source)
 		return false, errMsg
 	}
 	if isFormatValid(strings.TrimSpace(licenseKey.Value)) {

--- a/tasks/base/config/validateLicenseKey_test.go
+++ b/tasks/base/config/validateLicenseKey_test.go
@@ -208,7 +208,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\nUsing quotes around NEW_RELIC_LICENSE_KEY may cause inconsistent behavior. We highly recommend removing those quotes, and running NR Diagnostics again.\n\n"))
+				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\nUsing quotes around NEW_RELIC_LICENSE_KEY may cause inconsistent behavior. We highly recommend removing those quotes, and running the " + ThisProgramFullName + " again.\n\n"))
 
 			})
 		})

--- a/tasks/base/config/validateLicenseKey_test.go
+++ b/tasks/base/config/validateLicenseKey_test.go
@@ -208,7 +208,7 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 
 			It("Should return a None status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\nUsing quotes around NEW_RELIC_LICENSE_KEY may cause inconsistent behavior. We highly recommend removing those quotes, and running the " + ThisProgramFullName + " again.\n\n"))
+				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\nUsing quotes around NEW_RELIC_LICENSE_KEY may cause inconsistent behavior. We highly recommend removing those quotes, and running the " + tasks.ThisProgramFullName + " again.\n\n"))
 
 			})
 		})

--- a/tasks/base/env/admin_windows.go
+++ b/tasks/base/env/admin_windows.go
@@ -49,7 +49,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 	// 1- check FS - this will fail in docker (this is tested with a unit test)
 	isAdminFromFS, fsErr := p.adminFSCheck()
 	if isAdminFromFS {
-		result.Summary = "NR Diag detected having Elevated permissions"
+		result.Summary = ThisProgramFullName + " detected having Elevated permissions"
 		result.Status = tasks.Success
 		return result
 	} else if fsErr != nil {
@@ -59,7 +59,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 	// 2- check USERNAME env variable - will be Administrator if elevated (this is tested with a unit test)
 	isAdminFromUsernameEnvVar, usernameEnvVarErr := p.adminUsernameEnvVarCheck()
 	if isAdminFromUsernameEnvVar {
-		result.Summary = "NR Diag detected having Elevated permissions"
+		result.Summary = ThisProgramFullName + " detected having Elevated permissions"
 		result.Status = tasks.Success
 		return result
 	} else if usernameEnvVarErr != nil {
@@ -69,7 +69,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 	// 3- check logged in user (this is tested with an integration test)
 	isAdminFromLoggedInUser, loggedInUserErr := p.adminLoggedInUserCheck()
 	if isAdminFromLoggedInUser {
-		result.Summary = "NR Diag detected having Elevated permissions"
+		result.Summary = ThisProgramFullName + " detected having Elevated permissions"
 		result.Status = tasks.Success
 		return result
 	} else if loggedInUserErr != nil {
@@ -78,7 +78,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 
 	// not admin
 	result.Status = tasks.Warning
-	result.Summary = "NR Diag did not detect having Elevated permissions. Some Tasks may fail. If possible re-run from an Admin cmd prompt or PowerShell."
+	result.Summary = ThisProgramFullName + " did not detect having Elevated permissions. Some Tasks may fail. If possible re-run from an Admin cmd prompt or PowerShell."
 	if len(errorsSlice) > 0 {
 		result.Summary += "\n" + strconv.Itoa(len(errorsSlice)) + " errors encountered: "
 		for _, e := range errorsSlice {

--- a/tasks/base/env/admin_windows.go
+++ b/tasks/base/env/admin_windows.go
@@ -49,7 +49,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 	// 1- check FS - this will fail in docker (this is tested with a unit test)
 	isAdminFromFS, fsErr := p.adminFSCheck()
 	if isAdminFromFS {
-		result.Summary = ThisProgramFullName + " detected having Elevated permissions"
+		result.Summary = tasks.ThisProgramFullName + " detected having Elevated permissions"
 		result.Status = tasks.Success
 		return result
 	} else if fsErr != nil {
@@ -59,7 +59,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 	// 2- check USERNAME env variable - will be Administrator if elevated (this is tested with a unit test)
 	isAdminFromUsernameEnvVar, usernameEnvVarErr := p.adminUsernameEnvVarCheck()
 	if isAdminFromUsernameEnvVar {
-		result.Summary = ThisProgramFullName + " detected having Elevated permissions"
+		result.Summary = tasks.ThisProgramFullName + " detected having Elevated permissions"
 		result.Status = tasks.Success
 		return result
 	} else if usernameEnvVarErr != nil {
@@ -69,7 +69,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 	// 3- check logged in user (this is tested with an integration test)
 	isAdminFromLoggedInUser, loggedInUserErr := p.adminLoggedInUserCheck()
 	if isAdminFromLoggedInUser {
-		result.Summary = ThisProgramFullName + " detected having Elevated permissions"
+		result.Summary = tasks.ThisProgramFullName + " detected having Elevated permissions"
 		result.Status = tasks.Success
 		return result
 	} else if loggedInUserErr != nil {
@@ -78,7 +78,7 @@ func (p BaseEnvCheckWindowsAdmin) Execute(options tasks.Options, upstream map[st
 
 	// not admin
 	result.Status = tasks.Warning
-	result.Summary = ThisProgramFullName + " did not detect having Elevated permissions. Some Tasks may fail. If possible re-run from an Admin cmd prompt or PowerShell."
+	result.Summary = tasks.ThisProgramFullName + " did not detect having Elevated permissions. Some Tasks may fail. If possible re-run from an Admin cmd prompt or PowerShell."
 	if len(errorsSlice) > 0 {
 		result.Summary += "\n" + strconv.Itoa(len(errorsSlice)) + " errors encountered: "
 		for _, e := range errorsSlice {

--- a/tasks/base/log/copy.go
+++ b/tasks/base/log/copy.go
@@ -51,7 +51,7 @@ func (p BaseLogCopy) Execute(options tasks.Options, upstream map[string]tasks.Re
 	if len(logFilesPaths) < 1 {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "New Relic log file(s) not found where the " + ThisProgramFullName + " was executed, or in default agent log file paths. If you can see New Relic logs being generated, you will need to manually provide these logs if you are working with New Relic Support. Review the following document to send the proper level of logging for Support troubleshooting.",
+			Summary: "New Relic log file(s) not found where the " + tasks.ThisProgramFullName + " was executed, or in default agent log file paths. If you can see New Relic logs being generated, you will need to manually provide these logs if you are working with New Relic Support. Review the following document to send the proper level of logging for Support troubleshooting.",
 			URL:     "https://docs.newrelic.com/docs/agents/manage-apm-agents/troubleshooting/generate-new-relic-agent-logs-troubleshooting",
 		}
 	}
@@ -64,7 +64,7 @@ func (p BaseLogCopy) Execute(options tasks.Options, upstream map[string]tasks.Re
 	for _, file := range logFilesStatuses {
 		if !file.IsValid {
 			invalidLogFiles = append(invalidLogFiles, file.Path)
-			resultSummary += fmt.Sprintf("Warning! the " + ThisProgramFullName + " cannot collect New Relic log files from the provided path(%s):%s.If you are working with a support ticket, manually provide your New Relic log file for further troubleshooting\n", file.Path, (file.ErrorMsg).Error())
+			resultSummary += fmt.Sprintf("Warning! the " + tasks.ThisProgramFullName + " cannot collect New Relic log files from the provided path(%s):%s.If you are working with a support ticket, manually provide your New Relic log file for further troubleshooting\n", file.Path, (file.ErrorMsg).Error())
 		} else {
 			validLogFiles = append(validLogFiles, file.Path)
 		}

--- a/tasks/base/log/copy.go
+++ b/tasks/base/log/copy.go
@@ -51,7 +51,7 @@ func (p BaseLogCopy) Execute(options tasks.Options, upstream map[string]tasks.Re
 	if len(logFilesPaths) < 1 {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "New Relic log file(s) not found where NR Diagnostics was executed, or in default agent log file paths. If you can see New Relic logs being generated, you will need to manually provide these logs if you are working with New Relic Support. Review the following document to send the proper level of logging for Support troubleshooting.",
+			Summary: "New Relic log file(s) not found where the " + ThisProgramFullName + " was executed, or in default agent log file paths. If you can see New Relic logs being generated, you will need to manually provide these logs if you are working with New Relic Support. Review the following document to send the proper level of logging for Support troubleshooting.",
 			URL:     "https://docs.newrelic.com/docs/agents/manage-apm-agents/troubleshooting/generate-new-relic-agent-logs-troubleshooting",
 		}
 	}
@@ -64,7 +64,7 @@ func (p BaseLogCopy) Execute(options tasks.Options, upstream map[string]tasks.Re
 	for _, file := range logFilesStatuses {
 		if !file.IsValid {
 			invalidLogFiles = append(invalidLogFiles, file.Path)
-			resultSummary += fmt.Sprintf("Warning! NR Diagnostics cannot collect New Relic log files from the provided path(%s):%s.If you are working with a support ticket, manually provide your New Relic log file for further troubleshooting\n", file.Path, (file.ErrorMsg).Error())
+			resultSummary += fmt.Sprintf("Warning! the " + ThisProgramFullName + " cannot collect New Relic log files from the provided path(%s):%s.If you are working with a support ticket, manually provide your New Relic log file for further troubleshooting\n", file.Path, (file.ErrorMsg).Error())
 		} else {
 			validLogFiles = append(validLogFiles, file.Path)
 		}

--- a/tasks/dotnet/env/targetVersion_windows.go
+++ b/tasks/dotnet/env/targetVersion_windows.go
@@ -50,7 +50,7 @@ func (p DotNetEnvTargetVersion) Execute(options tasks.Options, upstream map[stri
 	configFiles := p.getNetConfigFiles(workingDir)
 	if len(configFiles) < 1 {
 		result.Status = tasks.Warning
-		result.Summary = "Unable to find app config file. Are you running NR Diag from your application's parent directory?"
+		result.Summary = "Unable to find app config file. Are you running the " ThisProgramFullName + " from your application's parent directory?"
 		result.URL = "https://docs.newrelic.com/docs/agents/manage-apm-agents/troubleshooting/new-relic-diagnostics"
 		return result
 	}

--- a/tasks/dotnet/env/targetVersion_windows.go
+++ b/tasks/dotnet/env/targetVersion_windows.go
@@ -13,7 +13,6 @@ type DotNetEnvTargetVersion struct {
 	returnStringInFile tasks.ReturnStringInFileFunc
 }
 
-
 // Identifier - This returns the Category, Subcategory and Name of each task
 func (p DotNetEnvTargetVersion) Identifier() tasks.Identifier {
 	return tasks.IdentifierFromString("DotNet/Env/TargetVersion")
@@ -50,7 +49,7 @@ func (p DotNetEnvTargetVersion) Execute(options tasks.Options, upstream map[stri
 	configFiles := p.getNetConfigFiles(workingDir)
 	if len(configFiles) < 1 {
 		result.Status = tasks.Warning
-		result.Summary = "Unable to find app config file. Are you running the " tasks.ThisProgramFullName + " from your application's parent directory?"
+		result.Summary = "Unable to find app config file. Are you running the " + tasks.ThisProgramFullName + " from your application's parent directory?"
 		result.URL = "https://docs.newrelic.com/docs/agents/manage-apm-agents/troubleshooting/new-relic-diagnostics"
 		return result
 	}

--- a/tasks/dotnet/env/targetVersion_windows.go
+++ b/tasks/dotnet/env/targetVersion_windows.go
@@ -50,7 +50,7 @@ func (p DotNetEnvTargetVersion) Execute(options tasks.Options, upstream map[stri
 	configFiles := p.getNetConfigFiles(workingDir)
 	if len(configFiles) < 1 {
 		result.Status = tasks.Warning
-		result.Summary = "Unable to find app config file. Are you running the " ThisProgramFullName + " from your application's parent directory?"
+		result.Summary = "Unable to find app config file. Are you running the " tasks.ThisProgramFullName + " from your application's parent directory?"
 		result.URL = "https://docs.newrelic.com/docs/agents/manage-apm-agents/troubleshooting/new-relic-diagnostics"
 		return result
 	}

--- a/tasks/dotnet/env/targetVersion_windows_test.go
+++ b/tasks/dotnet/env/targetVersion_windows_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Dotnet/Env/TargetVersion", func() {
 				Expect(result.Status).To(Equal(tasks.Warning))
 			})
 			It("should return an expected result summary", func() {
-				Expect(result.Summary).To(Equal("Unable to find app config file. Are you running NR Diag from your application's parent directory?"))
+				Expect(result.Summary).To(Equal("Unable to find app config file. Are you running the " + ThisProgramFullName + " from your application's parent directory?"))
 			})
 		})
 		Context("when unable to find .NET version", func() {

--- a/tasks/dotnet/env/targetVersion_windows_test.go
+++ b/tasks/dotnet/env/targetVersion_windows_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Dotnet/Env/TargetVersion", func() {
 				Expect(result.Status).To(Equal(tasks.Warning))
 			})
 			It("should return an expected result summary", func() {
-				Expect(result.Summary).To(Equal("Unable to find app config file. Are you running the " + ThisProgramFullName + " from your application's parent directory?"))
+				Expect(result.Summary).To(Equal("Unable to find app config file. Are you running the " + tasks.ThisProgramFullName + " from your application's parent directory?"))
 			})
 		})
 		Context("when unable to find .NET version", func() {

--- a/tasks/dotnet/requirements/messagingServicesCheck_windows.go
+++ b/tasks/dotnet/requirements/messagingServicesCheck_windows.go
@@ -71,7 +71,7 @@ func (p DotnetRequirementsMessagingServicesCheck) Execute(options tasks.Options,
 	if len(localDirs) < 1 {
 		return tasks.Result{
 			Status:  tasks.Error,
-			Summary: "Unable to determine the " + ThisProgramFullName + " working and executable directory paths.",
+			Summary: "Unable to determine the " + tasks.ThisProgramFullName + " working and executable directory paths.",
 		}
 	}
 

--- a/tasks/dotnet/requirements/messagingServicesCheck_windows.go
+++ b/tasks/dotnet/requirements/messagingServicesCheck_windows.go
@@ -71,7 +71,7 @@ func (p DotnetRequirementsMessagingServicesCheck) Execute(options tasks.Options,
 	if len(localDirs) < 1 {
 		return tasks.Result{
 			Status:  tasks.Error,
-			Summary: "Unable to determine NR Diag working and executable directory paths.",
+			Summary: "Unable to determine the " + ThisProgramFullName + " working and executable directory paths.",
 		}
 	}
 

--- a/tasks/dotnet/requirements/messagingServicesCheck_windows_test.go
+++ b/tasks/dotnet/requirements/messagingServicesCheck_windows_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Dotnet/Requirements/MessagingServicesCheck", func() {
 			})
 
 			It("should return an expected result summary", func() {
-				Expect(result.Summary).To(Equal("Unable to determine NR Diag working and executable directory paths."))
+				Expect(result.Summary).To(Equal("Unable to determine the " + ThisProgramFullName + " working and executable directory paths."))
 			})
 		})
 		Context("when no Dlls found", func() {

--- a/tasks/dotnet/requirements/messagingServicesCheck_windows_test.go
+++ b/tasks/dotnet/requirements/messagingServicesCheck_windows_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Dotnet/Requirements/MessagingServicesCheck", func() {
 			})
 
 			It("should return an expected result summary", func() {
-				Expect(result.Summary).To(Equal("Unable to determine the " + ThisProgramFullName + " working and executable directory paths."))
+				Expect(result.Summary).To(Equal("Unable to determine the " + tasks.ThisProgramFullName + " working and executable directory paths."))
 			})
 		})
 		Context("when no Dlls found", func() {

--- a/tasks/infra/agent/debug.go
+++ b/tasks/infra/agent/debug.go
@@ -63,7 +63,7 @@ func (p InfraAgentDebug) Execute(options tasks.Options, upstream map[string]task
 	if upstream["Base/Log/Copy"].Status != tasks.Success {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run NR Diag after setting the NRIA_LOG_FILE environment variable.",
+			Summary: "No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run the " + ThisProgramFullName + " after setting the NRIA_LOG_FILE environment variable.",
 			URL:     "https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/configuration/infrastructure-configuration-settings#log-file",
 		}
 	}

--- a/tasks/infra/agent/debug.go
+++ b/tasks/infra/agent/debug.go
@@ -63,7 +63,7 @@ func (p InfraAgentDebug) Execute(options tasks.Options, upstream map[string]task
 	if upstream["Base/Log/Copy"].Status != tasks.Success {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run the " + ThisProgramFullName + " after setting the NRIA_LOG_FILE environment variable.",
+			Summary: "No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run the " + tasks.ThisProgramFullName + " after setting the NRIA_LOG_FILE environment variable.",
 			URL:     "https://docs.newrelic.com/docs/infrastructure/install-configure-manage-infrastructure/configuration/infrastructure-configuration-settings#log-file",
 		}
 	}

--- a/tasks/infra/agent/debug_test.go
+++ b/tasks/infra/agent/debug_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Infra/Agent/Debug", func() {
 			})
 
 			It("should return an expected result summary", func() {
-				Expect(result.Summary).To(Equal("No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run NR Diag after setting the NRIA_LOG_FILE environment variable."))
+				Expect(result.Summary).To(Equal("No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run the " + ThisProgramFullName + " after setting the NRIA_LOG_FILE environment variable."))
 			})
 		})
 

--- a/tasks/infra/agent/debug_test.go
+++ b/tasks/infra/agent/debug_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Infra/Agent/Debug", func() {
 			})
 
 			It("should return an expected result summary", func() {
-				Expect(result.Summary).To(Equal("No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run the " + ThisProgramFullName + " after setting the NRIA_LOG_FILE environment variable."))
+				Expect(result.Summary).To(Equal("No New Relic Infrastructure log files detected. If your log files are in a custom location, re-run the " + tasks.ThisProgramFullName + " after setting the NRIA_LOG_FILE environment variable."))
 			})
 		})
 

--- a/tasks/java/jvm/vendorsVersions_test.go
+++ b/tasks/java/jvm/vendorsVersions_test.go
@@ -322,7 +322,7 @@ func TestCheckLegacySupported(t *testing.T) {
 		{os: "darwin", vendor: "HotSpot", version: "6", result: true},
 		{os: "darwin", vendor: "HotSpot", version: "7", result: false},
 
-		// No "os: solaris" tests because we don't compile NR Diag for Solaris
+		// No "os: solaris" tests because we don't compile the Diagnostics CLI for Solaris
 
 		// IBM JVM version 6 for Linux
 		{os: "linux", vendor: "IBM", version: "6", result: true},

--- a/tasks/node/env/dependencies.go
+++ b/tasks/node/env/dependencies.go
@@ -60,7 +60,7 @@ func (p NodeEnvDependencies) Execute(option tasks.Options, upstream map[string]t
 	if npmErr != nil && (npmErr.Error() != "exit status 1") {
 		return tasks.Result{
 			Status:      tasks.Error,
-			Summary:     npmErr.Error() + ": npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors",
+			Summary:     npmErr.Error() + ": npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + tasks.ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors",
 			FilesToCopy: filesToCopy,
 		}
 	}

--- a/tasks/node/env/dependencies.go
+++ b/tasks/node/env/dependencies.go
@@ -60,7 +60,7 @@ func (p NodeEnvDependencies) Execute(option tasks.Options, upstream map[string]t
 	if npmErr != nil && (npmErr.Error() != "exit status 1") {
 		return tasks.Result{
 			Status:      tasks.Error,
-			Summary:     npmErr.Error() + ": npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that NR Diagnostics is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors",
+			Summary:     npmErr.Error() + ": npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors",
 			FilesToCopy: filesToCopy,
 		}
 	}

--- a/tasks/node/env/dependencies_test.go
+++ b/tasks/node/env/dependencies_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Node/Env/Dependencies", func() {
 				Expect(result.Status).To(Equal(tasks.Error))
 			})
 			It("Should return a Failure result summary", func() {
-				Expect(result.Summary).To(Equal("an error message: npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors"))
+				Expect(result.Summary).To(Equal("an error message: npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + tasks.ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors"))
 			})
 		})
 		Context("When NodeModulesVersions length is zero", func() {

--- a/tasks/node/env/dependencies_test.go
+++ b/tasks/node/env/dependencies_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Node/Env/Dependencies", func() {
 				Expect(result.Status).To(Equal(tasks.Error))
 			})
 			It("Should return a Failure result summary", func() {
-				Expect(result.Summary).To(Equal("an error message: npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that NR Diagnostics is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors"))
+				Expect(result.Summary).To(Equal("an error message: npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors"))
 			})
 		})
 		Context("When NodeModulesVersions length is zero", func() {

--- a/tasks/node/env/npmPackage.go
+++ b/tasks/node/env/npmPackage.go
@@ -66,7 +66,7 @@ func (p NodeEnvNpmPackage) Execute(options tasks.Options, upstream map[string]ta
 	if len(foundFiles) == 0 {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "The package.json and package-lock.json files were not found where NR Diagnostics was executed. Please ensure the NR Diagnostics executable is within your application's directory alongside your package.json file",
+			Summary: "The package.json and package-lock.json files were not found where the " + ThisProgramFullName + " was executed. Please ensure the " + ThisProgramFullName + " executable is within your application's directory alongside your package.json file",
 		}
 	}
 

--- a/tasks/node/env/npmPackage.go
+++ b/tasks/node/env/npmPackage.go
@@ -66,7 +66,7 @@ func (p NodeEnvNpmPackage) Execute(options tasks.Options, upstream map[string]ta
 	if len(foundFiles) == 0 {
 		return tasks.Result{
 			Status:  tasks.Failure,
-			Summary: "The package.json and package-lock.json files were not found where the " + ThisProgramFullName + " was executed. Please ensure the " + ThisProgramFullName + " executable is within your application's directory alongside your package.json file",
+			Summary: "The package.json and package-lock.json files were not found where the " + tasks.ThisProgramFullName + " was executed. Please ensure the " + tasks.ThisProgramFullName + " executable is within your application's directory alongside your package.json file",
 		}
 	}
 

--- a/tasks/node/env/npmPackage_test.go
+++ b/tasks/node/env/npmPackage_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Node/Env/NpmPackage", func() {
 
 			It("Should return a failure result status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal("The package.json and package-lock.json files were not found where NR Diagnostics was executed. Please ensure the NR Diagnostics executable is within your application's directory alongside your package.json file"))
+				Expect(result.Summary).To(Equal("The package.json and package-lock.json files were not found where the " + ThisProgramFullName + " was executed. Please ensure the " + ThisProgramFullName + " executable is within your application's directory alongside your package.json file"))
 			})
 		})
 

--- a/tasks/node/env/npmPackage_test.go
+++ b/tasks/node/env/npmPackage_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Node/Env/NpmPackage", func() {
 
 			It("Should return a failure result status and summary", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal("The package.json and package-lock.json files were not found where the " + ThisProgramFullName + " was executed. Please ensure the " + ThisProgramFullName + " executable is within your application's directory alongside your package.json file"))
+				Expect(result.Summary).To(Equal("The package.json and package-lock.json files were not found where the " + tasks.ThisProgramFullName + " was executed. Please ensure the " + tasks.ThisProgramFullName + " executable is within your application's directory alongside your package.json file"))
 			})
 		})
 

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -20,8 +20,8 @@ type Result struct {
 // Status statusEnum listing of valid values for status
 type Status int
 
-//Constant for the name of the program to be used in task summaries 
-const ThisProgramFullName = "Diagnostics CLI" 
+//ThisProgramFullName is a constant for the name of the program to be used in task summaries
+const ThisProgramFullName = "Diagnostics CLI"
 
 //Constants for use by the status property above
 const (

--- a/tasks/tasks.go
+++ b/tasks/tasks.go
@@ -20,6 +20,9 @@ type Result struct {
 // Status statusEnum listing of valid values for status
 type Status int
 
+//Constant for the name of the program to be used in task summaries 
+const ThisProgramFullName = "Diagnostics CLI" 
+
 //Constants for use by the status property above
 const (
 	//None - this task does not apply to this system and has no meaninful data to report.

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -158,7 +158,7 @@ func SendUsageData(results []registration.TaskResult, runID string) {
 
 	prompt := response.Survey.Prompt
 	if prompt == "" {
-		prompt = "We'd love to know more about your experience using NR Diagnostics! Please visit:"
+		prompt = "We'd love to know more about your experience using the " + ThisProgramFullName + "! Please visit:"
 	}
 
 	log.Info(prompt)

--- a/usage/usage.go
+++ b/usage/usage.go
@@ -158,7 +158,7 @@ func SendUsageData(results []registration.TaskResult, runID string) {
 
 	prompt := response.Survey.Prompt
 	if prompt == "" {
-		prompt = "We'd love to know more about your experience using the " + ThisProgramFullName + "! Please visit:"
+		prompt = "We'd love to know more about your experience using the " + tasks.ThisProgramFullName + "! Please visit:"
 	}
 
 	log.Info(prompt)


### PR DESCRIPTION
# Issue
The Diagnostics CLI was referred to by a number of different names in documents and summaries 
# Goals
Consistent naming of the tool
# Implementation Details
changed name directly in docs and a few places outside tasks. In tasks created a const named ThisProgramFullName in tasks.go to use in summaries and other task output as needed
# How to Test
Should just be standard tests