### PR TITLE
Validate nrjmx mbeans

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,5 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/sys v0.0.0-20201013132646-2da7054afaeb
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
-	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/go.mod
+++ b/go.mod
@@ -18,5 +18,6 @@ require (
 	github.com/stretchr/testify v1.6.1 // indirect
 	golang.org/x/sys v0.0.0-20201013132646-2da7054afaeb
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
+	gopkg.in/yaml.v2 v2.3.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 )

--- a/tasks/infra/config/config.go
+++ b/tasks/infra/config/config.go
@@ -23,7 +23,7 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 
 	if runtime.GOOS != "windows" {
 		registrationFunc(InfraConfigValidateJMX{
-			mCmdExecutor: multiCmdExecutor,
+			mCmdExecutor: tasks.MultiCmdExecutor,
 		}, true)
 	}
 }

--- a/tasks/infra/config/config_test.go
+++ b/tasks/infra/config/config_test.go
@@ -6,9 +6,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
 func TestInfraConfigIntegrations(t *testing.T) {
@@ -74,7 +74,7 @@ func TestRegisterWith(t *testing.T) {
 
 	if runtime.GOOS != "windows" { //we don't register InfraConfigValidateJMX in windows due to bug
 		expectedRegisteredTasks = append(expectedRegisteredTasks, InfraConfigValidateJMX{
-			mCmdExecutor: multiCmdExecutor,
+			mCmdExecutor: tasks.MultiCmdExecutor,
 		})
 	}
 

--- a/tasks/infra/config/validateJMX_test.go
+++ b/tasks/infra/config/validateJMX_test.go
@@ -218,7 +218,7 @@ var _ = Describe("Infra/Config/ValidateJMX", func() {
 			It("should redact auth from payload JSON", func() {
 				resultPayload := result.Payload.(JmxConfig)
 				payloadJSON, _ := json.MarshalIndent(resultPayload, "", "	")
-				expectedPayloadJSON := "{\n\t\"jmx_host\": \"jmx-host.localnet\",\n\t\"jmx_port\": \"9999\",\n\t\"jmx_user\": \"_REDACTED_\",\n\t\"jmx_pass\": \"_REDACTED_\",\n\t\"collection_files\": \"/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml\",\n\t\"java_version\": \"\",\n\t\"ps_ef_grep_jmx\": \"success\"\n}"
+				expectedPayloadJSON := "{\n\t\"jmx_host\": \"jmx-host.localnet\",\n\t\"jmx_port\": \"9999\",\n\t\"jmx_user\": \"_REDACTED_\",\n\t\"jmx_pass\": \"_REDACTED_\",\n\t\"collection_files\": \"/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml\",\n\t\"java_version\": \"Unable to find a Java path/version after running the command: java -version\",\n\t\"jmx_process_arguments\": [\n\t\t\"Unable to find a running JVM process that has JMX enabled or configured in its arguments\"\n\t]\n}"
 				Expect(string(payloadJSON)).To(Equal(expectedPayloadJSON))
 			})
 		})

--- a/tasks/infra/env/env.go
+++ b/tasks/infra/env/env.go
@@ -17,5 +17,7 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		checkForClockSkew: checkForClockSkew,
 		runtimeOS:         runtime.GOOS,
 	}, true)
-
+	registrationFunc(InfraEnvnrjmxMbeans{
+		mCmdExecutor: multiCmdExecutor,
+	}, true)
 }

--- a/tasks/infra/env/env.go
+++ b/tasks/infra/env/env.go
@@ -17,7 +17,7 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		checkForClockSkew: checkForClockSkew,
 		runtimeOS:         runtime.GOOS,
 	}, true)
-	registrationFunc(InfraEnvnrjmxMbeans{
-		mCmdExecutor: multiCmdExecutor,
+	registrationFunc(InfraEnvNrjmxMbeans{
+		mCmdExecutor: tasks.MultiCmdExecutor,
 	}, true)
 }

--- a/tasks/infra/env/env.go
+++ b/tasks/infra/env/env.go
@@ -18,6 +18,7 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		runtimeOS:         runtime.GOOS,
 	}, true)
 	registrationFunc(InfraEnvNrjmxMbeans{
-		mCmdExecutor: tasks.MultiCmdExecutor,
+		getMBeanQueriesFromJMVMetricsYml: getMBeanQueriesFromJMVMetricsYml,
+		executeNrjmxCmdToFindBeans:       executeNrjmxCmdToFindBeans,
 	}, true)
 }

--- a/tasks/infra/env/nrjmxMbeans.go
+++ b/tasks/infra/env/nrjmxMbeans.go
@@ -9,7 +9,7 @@ import (
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks/infra/config"
 	infraConfig "github.com/newrelic/newrelic-diagnostics-cli/tasks/infra/config"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 type collectionDefinitionParser struct {
@@ -28,7 +28,7 @@ type beanDefinitionParser struct {
 // InfraEnvNrjmxMbeans - This struct defines the task
 type InfraEnvNrjmxMbeans struct {
 	getMBeanQueriesFromJMVMetricsYml func(string) ([]string, error)
-	executeNrjmxCmdToFindBeans func([]string, infraConfig.JmxConfig) ([]string, map[string]string)
+	executeNrjmxCmdToFindBeans       func([]string, infraConfig.JmxConfig) ([]string, map[string]string)
 }
 
 // Identifier - This returns the Category, Subcategory and Name of each task

--- a/tasks/infra/env/nrjmxMbeans.go
+++ b/tasks/infra/env/nrjmxMbeans.go
@@ -1,0 +1,147 @@
+package env
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks/infra/config"
+)
+
+// InfraEnvnrjmxMbeans - This struct defines the task
+type InfraEnvnrjmxMbeans struct {
+	mCmdExecutor               func(cmdWrapper, cmdWrapper) ([]byte, error)
+	executeNrjmxCmdToFindBeans func(string) (string, error)
+}
+
+//cmdWrapper is used to specify commands & args to be passed to the multi-command executor (mCmdExecutor)
+//allowing for: cmd1 args | cmd2 args
+type cmdWrapper struct {
+	cmd  string
+	args []string
+}
+
+// Identifier - This returns the Category, Subcategory and Name of each task
+func (p InfraEnvnrjmxMbeans) Identifier() tasks.Identifier {
+	return tasks.IdentifierFromString("Infra/Env/nrjmxMbeans")
+}
+
+// Explain - Returns the help text for each individual task
+func (p InfraEnvnrjmxMbeans) Explain() string {
+	return "Validate list of Mbeans against JMX integrations"
+}
+
+// Dependencies - Returns the dependencies for each task.
+func (p InfraEnvnrjmxMbeans) Dependencies() []string {
+	return []string{
+		"Infra/Config/ValidateJMX",
+	}
+}
+
+func (p InfraEnvnrjmxMbeans) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
+	if upstream["Infra/Config/ValidateJMX"].Status != tasks.Warning || upstream["Infra/Config/ValidateJMX"].Status != tasks.Success {
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: "Infra/Config/ValidateJMX did not pass our validation. That issue will need to be resolved first before this task can be executed.",
+		}
+	}
+
+	jmxConfig, ok := upstream["Infra/Config/ValidateJMX"].Payload.(config.JmxConfig)
+
+	if !ok {
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: "Task did not meet requirements necessary to run: type assertion failure",
+		}
+	}
+
+	beanQueries := getBeanQueriesFromJMVMetricsYml(jmxConfig.CollectionFiles)
+
+	success, emptyResult, errResult := executeNrjmxCmdToFindBeans(beanQueries, jmxConfig)
+
+	var failureResult string
+	if len(emptyResult) > 0 {
+		failureResult = fmt.Sprintf("We are able to run our nrjmx integration directly against your JMX server. However, the following query/queries found in jvm-metrics.yml may not exist or will need to be redefined in your yml because we are unable to find it among the MBeans listed on your server: %s", strings.Join(emptyResult, ", "))
+	}
+
+	// if cmdOutput == {} {
+	// 	return tasks.Result{
+	// 		Status: tasks.Failure,
+	// 		Summary: "We are able to run our nrjmx integration directly against your JMX server. However, the query found in jvm-metrics.yml may not exist or will need to be redefined in your yml because we are unable to find it among the MBeans listed on your server.",
+	// 	}
+	// }
+
+	return tasks.Result{
+		Status:  tasks.Success,
+		Summary: "Successfully connected to configured JMX Integration config",
+	}
+
+}
+
+func getBeanQueriesFromJMVMetricsYml(pathToJvmMetricsYml string) []string {
+
+}
+
+func executeNrjmxCmdToFindBeans(beanQueries []string, jmxConfig config.JmxConfig) ([]string, []string, map[string]string) {
+
+	//echo 'Glassbox:type=OfflineHandler,name=Offline_client_clingine' | ./nrjmx -H localhost -P 5002 -v -d
+	//{}
+	successCmdOutputs := []string{}
+	errorCmdOutputs := make(map[string]string)
+	emptyCmdOutputs := []string{}
+	for _, query := range beanQueries {
+		cmd1 := cmdWrapper{
+			cmd:  "echo",
+			args: []string{query},
+		}
+		jmxArgs := []string{"-hostname", jmxConfig.Host, "-port", jmxConfig.Port, "-v", "-d", "-"}
+		cmd2 := cmdWrapper{
+			cmd:  "./nrjmx", // note we're using nrjmx here instead of nr-jmx, nrjmx is the raw connect to JMX command while nr-jmx is the wrapper that queries based on collection files
+			args: jmxArgs,
+		}
+
+		output, err := multiCmdExecutor(cmd1, cmd2)
+		log.Debug("output", string(output))
+		//nrjmx returns an error exit code (in err) and the meaningful error in output if there is a failure connecting
+		//if nrjmx is not installed, output will be empty and the meaninful msg will be in err
+		if err != nil {
+			if len(output) == 0 {
+				errorCmdOutputs[query] = err.Error()
+			}
+			errorCmdOutputs[query] = err.Error() + ": " + string(output)
+		}
+		if strings.TrimSpace(string(output)) == "{}" {
+			emptyCmdOutputs = append(emptyCmdOutputs, query)
+		} else {
+			successCmdOutputs = append(successCmdOutputs, query)
+		}
+	}
+	return successCmdOutputs, emptyCmdOutputs, errorCmdOutputs
+}
+
+// takes multiple commands and pipes the first into the second
+func multiCmdExecutor(cmdWrapper1, cmdWrapper2 cmdWrapper) ([]byte, error) {
+
+	cmd1 := exec.Command(cmdWrapper1.cmd, cmdWrapper1.args...)
+	cmd2 := exec.Command(cmdWrapper2.cmd, cmdWrapper2.args...)
+
+	// Get the pipe of Stdout from cmd1 and assign it
+	// to the Stdin of cmd2.
+	pipe, err := cmd1.StdoutPipe()
+	if err != nil {
+		return []byte{}, err
+	}
+	cmd2.Stdin = pipe
+
+	// Start() cmd1, so we don't block on it.
+	err = cmd1.Start()
+	if err != nil {
+		return []byte{}, err
+	}
+
+	// Run Output() on cmd2 to capture the output.
+	return cmd2.CombinedOutput()
+
+}

--- a/tasks/infra/env/nrjmxMbeans_test.go
+++ b/tasks/infra/env/nrjmxMbeans_test.go
@@ -1,0 +1,107 @@
+package env
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	infraConfig "github.com/newrelic/newrelic-diagnostics-cli/tasks/infra/config"
+)
+
+var _ = Describe("Infra/Env/NrjmxMbeans", func() {
+
+	var p InfraEnvNrjmxMbeans
+
+	Describe("Dependencies()", func() {
+		It("Should return expected dependencies", func() {
+			Expect(p.Dependencies()).To(Equal([]string{"Infra/Config/ValidateJMX"}))
+		})
+	})
+
+	Describe("Execute()", func() {
+		var (
+			options  tasks.Options
+			upstream map[string]tasks.Result
+			result   tasks.Result
+		)
+
+		JustBeforeEach(func() {
+			result = p.Execute(options, upstream)
+		})
+
+		Context("When one of the mbeans is not found", func() {
+
+			BeforeEach(func() {
+
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Infra/Config/ValidateJMX": tasks.Result{
+						Status: tasks.Success,
+						Payload: infraConfig.JmxConfig{
+							Host:                  "localhost",
+							Port:                  "8080",
+							User:                  "Admin",
+							Password:              "Admin",
+							CollectionFiles:       "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml",
+							JavaVersion:           "openjdk version \"11.0.9.1\" 2020-11-04\nOpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)\nOpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)\n",
+							JmxProcessCmdlineArgs: "vagrant   8599  2741  0 Nov23 pts/0    00:00:39 java -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.ssl=false -jar -javaagent:newrelic/newrelic.jar build/libs/lucessqs-1.0-SNAPSHOT.jar\nroot     24530 24451  0 01:27 pts/1    00:00:00 grep jmx\n",
+						},
+					},
+				}
+				p.getMBeanQueriesFromJMVMetricsYml = func(string) ([]string, error) {
+					return []string{"java.lang:type=OperatingSystem", "java.lang:type=GarbageCollector"}, nil
+				}
+				/*Sample of unsuccesful output returned by cmdExecutor: []byte("{}\nNov 24, 2020 3:50:29 PM org.newrelic.nrjmx.JMXFetcher run\nFINE: Stopped receiving data, leaving...\n"), nil*/
+				p.executeNrjmxCmdToFindBeans = func([]string, infraConfig.JmxConfig) ([]string, map[string]string) {
+					return []string{"java.lang:type=OperatingSystem"}, make(map[string]string)
+				}
+			})
+
+			It("should return an expected Failure result status", func() {
+				Expect(result.Status).To(Equal(tasks.Failure))
+			})
+
+			It("should return an expected Failure result summary", func() {
+				Expect(result.Summary).To(Equal("In order to validate your queries defined in your metrics yml file against our JMX integration, we attempted to parsed them and ran each of them with the command echo {yourquery} | nrjmx -H localhost -P 8080 -v -d -\nThese queries returned an empty object({}): java.lang:type=OperatingSystem\nThis can mean that either those mBeans are not available to this JMX server or that the queries targetting them may need to be reformatted in the metrics yml file.\n"))
+			})
+		})
+
+		Context("When mbean found returns metrics", func() {
+
+			BeforeEach(func() {
+
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Infra/Config/ValidateJMX": tasks.Result{
+						Status: tasks.Success,
+						Payload: infraConfig.JmxConfig{
+							Host:                  "localhost",
+							Port:                  "8080",
+							User:                  "Admin",
+							Password:              "Admin",
+							CollectionFiles:       "/etc/newrelic-infra/integrations.d/jvm-metrics.yml",
+							JavaVersion:           "openjdk version \"11.0.9.1\" 2020-11-04\nOpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)\nOpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)\n",
+							JmxProcessCmdlineArgs: "vagrant   8599  2741  0 Nov23 pts/0    00:00:39 java -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.ssl=false -jar -javaagent:newrelic/newrelic.jar build/libs/lucessqs-1.0-SNAPSHOT.jar\nroot     24530 24451  0 01:27 pts/1    00:00:00 grep jmx\n",
+						},
+					},
+				}
+				p.getMBeanQueriesFromJMVMetricsYml = func(string) ([]string, error) {
+					return []string{"java.lang:type=OperatingSystem"}, nil
+				}
+				/*Sample of successful output returned by cmdExecutor: []byte("Nov 24, 2020 3:50:15 PM org.newrelic.nrjmx.JMXFetcher queryAttributes\nFINE: Unsuported data type (class javax.management.ObjectName) for bean java.lang:type=OperatingSystem,attr=ObjectName" + `{"java.lang:type\u003dOperatingSystem,attr\u003dSystemLoadAverage":0.55,"java.lang:type\u003dOperatingSystem,attr\u003dArch":"amd64","java.lang:type\u003dOperatingSystem,attr\u003dOpenFileDescriptorCount":36,"java.lang:type\u003dOperatingSystem,attr\u003dProcessCpuLoad":0.018476791347453808,"java.lang:type\u003dOperatingSystem,attr\u003dMaxFileDescriptorCount":1048576,"java.lang:type\u003dOperatingSystem,attr\u003dCommittedVirtualMemorySize":4074438656,"java.lang:type\u003dOperatingSystem,attr\u003dFreePhysicalMemorySize":3892604928,"java.lang:type\u003dOperatingSystem,attr\u003dTotalSwapSpaceSize":0,"java.lang:type\u003dOperatingSystem,attr\u003dName":"Linux","java.lang:type\u003dOperatingSystem,attr\u003dVersion":"4.15.0-72-generic","java.lang:type\u003dOperatingSystem,attr\u003dTotalPhysicalMemorySize":5193482240,"java.lang:type\u003dOperatingSystem,attr\u003dSystemCpuLoad":0.05002253267237495,"java.lang:type\u003dOperatingSystem,attr\u003dAvailableProcessors":2,"java.lang:type\u003dOperatingSystem,attr\u003dFreeSwapSpaceSize":0,"java.lang:type\u003dOperatingSystem,attr\u003dProcessCpuTime":24500000000}` + "\nNov 24, 2020 3:50:15 PM org.newrelic.nrjmx.JMXFetcher run\nFINE: Stopped receiving data, leaving...\n"), nil*/
+				p.executeNrjmxCmdToFindBeans = func([]string, infraConfig.JmxConfig) ([]string, map[string]string) {
+					return []string{}, make(map[string]string)
+				}
+			})
+
+			It("should return an expected success result status", func() {
+				Expect(result.Status).To(Equal(tasks.Success))
+			})
+
+			It("should return an expected success result summary", func() {
+				Expect(result.Summary).To(Equal("In order to validate your queries defined in your metrics yml file against our JMX integration, we attempted to parsed them and ran each of them with the command echo {yourquery} | nrjmx -H localhost -P 8080 -v -d -\nAll queries returned successful metrics! The nrjmx integration is able to connect to the JMX server and query all the Mbeans that you had configured through your collection files."))
+			})
+		})
+	})
+
+})

--- a/tasks/infra/env/nrjmxMbeans_test.go
+++ b/tasks/infra/env/nrjmxMbeans_test.go
@@ -38,13 +38,19 @@ var _ = Describe("Infra/Env/NrjmxMbeans", func() {
 					"Infra/Config/ValidateJMX": tasks.Result{
 						Status: tasks.Success,
 						Payload: infraConfig.JmxConfig{
-							Host:                  "localhost",
-							Port:                  "8080",
-							User:                  "Admin",
-							Password:              "Admin",
-							CollectionFiles:       "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml",
-							JavaVersion:           "openjdk version \"11.0.9.1\" 2020-11-04\nOpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)\nOpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)\n",
-							JmxProcessCmdlineArgs: "vagrant   8599  2741  0 Nov23 pts/0    00:00:39 java -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.ssl=false -jar -javaagent:newrelic/newrelic.jar build/libs/lucessqs-1.0-SNAPSHOT.jar\nroot     24530 24451  0 01:27 pts/1    00:00:00 grep jmx\n",
+							Host:            "localhost",
+							Port:            "8080",
+							User:            "Admin",
+							Password:        "Admin",
+							CollectionFiles: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml",
+							JavaVersion:     "openjdk version \"11.0.9.1\" 2020-11-04\nOpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)\nOpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)\n",
+							JmxProcessCmdlineArgs: []string{
+								"-Dcom.sun.management.jmxremote.password.file=_REDACTED_",
+								"-Dcom.sun.management.jmxremote",
+								"-Dcom.sun.management.jmxremote.authenticate=true",
+								"-Dcom.sun.management.jmxremote.port=9010",
+								"-Dcom.sun.management.jmxremote.ssl=false",
+							},
 						},
 					},
 				}
@@ -75,13 +81,19 @@ var _ = Describe("Infra/Env/NrjmxMbeans", func() {
 					"Infra/Config/ValidateJMX": tasks.Result{
 						Status: tasks.Success,
 						Payload: infraConfig.JmxConfig{
-							Host:                  "localhost",
-							Port:                  "8080",
-							User:                  "Admin",
-							Password:              "Admin",
-							CollectionFiles:       "/etc/newrelic-infra/integrations.d/jvm-metrics.yml",
-							JavaVersion:           "openjdk version \"11.0.9.1\" 2020-11-04\nOpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)\nOpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)\n",
-							JmxProcessCmdlineArgs: "vagrant   8599  2741  0 Nov23 pts/0    00:00:39 java -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=9010 -Dcom.sun.management.jmxremote.ssl=false -jar -javaagent:newrelic/newrelic.jar build/libs/lucessqs-1.0-SNAPSHOT.jar\nroot     24530 24451  0 01:27 pts/1    00:00:00 grep jmx\n",
+							Host:            "localhost",
+							Port:            "8080",
+							User:            "Admin",
+							Password:        "Admin",
+							CollectionFiles: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml",
+							JavaVersion:     "openjdk version \"11.0.9.1\" 2020-11-04\nOpenJDK Runtime Environment (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04)\nOpenJDK 64-Bit Server VM (build 11.0.9.1+1-Ubuntu-0ubuntu1.18.04, mixed mode, sharing)\n",
+							JmxProcessCmdlineArgs: []string{
+								"-Dcom.sun.management.jmxremote.password.file=_REDACTED_",
+								"-Dcom.sun.management.jmxremote",
+								"-Dcom.sun.management.jmxremote.authenticate=true",
+								"-Dcom.sun.management.jmxremote.port=9010",
+								"-Dcom.sun.management.jmxremote.ssl=false",
+							},
 						},
 					},
 				}

--- a/tasks/java/env/version.go
+++ b/tasks/java/env/version.go
@@ -25,7 +25,8 @@ func (p JavaEnvVersion) Explain() string {
 // Dependencies - Returns the dependencies for each task. When executed by name each dependency will be executed as well and the results from that dependency passed in to the downstream task
 func (p JavaEnvVersion) Dependencies() []string {
 	return []string{
-		"Java/Config/Agent", //This identifies this task as dependent on "Java/Config/Agent" and so the results from that task will be passed to this task. See the execute method to see how to interact with the results.
+		"Java/Config/Agent",
+		"Infra/Config/Agent",
 	}
 }
 
@@ -34,7 +35,7 @@ func (p JavaEnvVersion) Dependencies() []string {
 func (p JavaEnvVersion) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
 	var result tasks.Result //This is what we will use to pass the output from this task back to the core and report to the UI
 
-	if upstream["Java/Config/Agent"].Status == tasks.Success {
+	if upstream["Java/Config/Agent"].Status == tasks.Success || upstream["Infra/Config/Agent"].Status == tasks.Success {
 		version, err := getJREVersion()
 		if err != nil {
 			result.Summary = "Java not found in PATH"

--- a/tasks/java/env/version.go
+++ b/tasks/java/env/version.go
@@ -39,7 +39,7 @@ func (p JavaEnvVersion) Execute(options tasks.Options, upstream map[string]tasks
 		version, err := getJREVersion()
 		if err != nil {
 			result.Summary = "Java not found in PATH"
-			result.Status = tasks.Warning //Do we want a URL in this one?
+			result.Status = tasks.Warning
 		} else {
 			result.Summary = version
 			result.Status = tasks.Info

--- a/tasks/taskHelpers.go
+++ b/tasks/taskHelpers.go
@@ -69,7 +69,7 @@ func FindFiles(patterns []string, paths []string) []string {
 // FindProcessByNameFunc - allows FindProcessByName to be dependency injected
 type FindProcessByNameFunc func(string) ([]process.Process, error)
 
-// FindProcessByName - returns array of processes matching string name, or an error if we can't gather a list of processes
+// FindProcessByName - returns array of processes matching string name, or an error if we can't gather a list of processes, or an empty slice and nil if we found no processes with that specific name
 func FindProcessByName(name string) ([]process.Process, error) {
 	var processList []process.Process
 
@@ -745,11 +745,11 @@ type JavaProcArgs struct {
 	Args   []string
 }
 
-// GetJavaProcArgs return a slice of JavaProcArgs
+// GetJavaProcArgs returns a slice of JavaProcArgs struct with two fields: ProcID(int32) and Args([]string)
 func GetJavaProcArgs() []JavaProcArgs {
 	javaProcs, err := FindProcessByName("java")
 	if err != nil {
-		log.Debug("We encountered an error while detecting all running Java processes: " + err.Error())
+		log.Info("We encountered an error while detecting all running Java processes: " + err.Error())
 	}
 	if javaProcs == nil {
 		return []JavaProcArgs{}
@@ -758,7 +758,7 @@ func GetJavaProcArgs() []JavaProcArgs {
 	for _, proc := range javaProcs {
 		cmdLineArgsSlice, err := GetCmdLineArgs(proc)
 		if err != nil {
-			log.Debug("Error getting command line options while running GetCmdLineArgs(proc)")
+			log.Info("Error getting command line options while running GetCmdLineArgs(proc)")
 		}
 		javaProcArgs = append(javaProcArgs, JavaProcArgs{ProcID: proc.Pid, Args: cmdLineArgsSlice})
 	}


### PR DESCRIPTION
# Issue
Not an issue, we are adding new features that I'll describe in the next section. 
# Goals
1)Adding a task Infra/Env/NrjmxBeans: Validate that the mbeans that the customer wants to query with the JMX integration are available for the integration to pull from.
2)Add two new fields to the struct JmxConfig found in the task Infra/Config/ValidateJMX: This task is mainly used by TSEs to troubleshoot that a JMX server cannot connect to our JMX integration, and not so much for a customer to understand WHY a connection is failing. This is because we only output the error found, but we do not judge what the error means.
With that same purpose of using this task only to provide data to TSEs to troubleshoot, I have added two new fields to this task struct that contains information about the Java version and the cmdline arguments for JMX. This specific information was requested by infra TSEs after I met with them and they said they use those 2 pieces of information to troubleshoot alongside the error that nrdiag provides. This information will only be provided to TSEs and not customers as it only shows up in the payload result, and not in the summary result.

# Implementation Details

1)Infra/Env/NrjmxMbeans:
-It will parse through the JMX integration metrics files listed under in collection_files field found in the jmx-config.yml
-It will grab the all queries defined in those metrics files and run them against the command `{queryname} | nrjmx -H %s -P %s -v -d -`
-If any of the queries return an empty object, it will warn the customer about this query not being available to the integration

2)Infra/Config/ValidateJMX:
-To get data the java version, I am leveraging the Java/Env/Version task to get the payload string
-To get the cmdline arguments for JMX, I am running this command `ps -ef | grep jmx` and converting the output []bytes to a string. Then adding that string to our result payload for TSE to interpret that string to the best of their knowledge. 

# How to Test
I have added a couple of unit test to the new task: Infra/Env/NrjmxMbeans.
I have also smoke tested in a linux environment that has JVM processes running and one of them had JMX enabled. I installed and configured the JMX integration to point to the incorrect port for the JMX server just to see the task fail with a very common mistake customers make. 

If you are interested in smoke testing this task, you'll have to follow these instructions to set the JMX integration: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration

To enable JMX metrics on your testing app, you can pass arguments like these when you start up your java app: 
java-jar -Dcom.sun.management.jmxremote.password.file=jmxremote.password-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=true-Dcom.sun.management.jmxremote.port=9010-Dcom.sun.management.jmxremote.ssl=false -pathtoyourapp.jar

Then you'll have to checkout into this branch and run ./scripts/build.sh to get the linux binary and drop the binary in your JMX server. This task does not run yet on windows. Though I am planning to on my next PR to fix a bug in ValidateJMX task that does not allow for this task to run on Windows.