### PR TITLE
Issue 1/update infra config validate jmx forwindows

### DIFF
--- a/tasks/infra/config/config.go
+++ b/tasks/infra/config/config.go
@@ -20,10 +20,7 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		runtimeOS: runtime.GOOS,
 	}, true)
 	registrationFunc(InfraConfigIntegrationsValidateJson{}, true)
-
-	if runtime.GOOS != "windows" {
-		registrationFunc(InfraConfigValidateJMX{
-			mCmdExecutor: tasks.MultiCmdExecutor,
-		}, true)
-	}
+	registrationFunc(InfraConfigValidateJMX{
+		mCmdExecutor: tasks.MultiCmdExecutor,
+	}, true)
 }

--- a/tasks/infra/config/config_test.go
+++ b/tasks/infra/config/config_test.go
@@ -26,12 +26,7 @@ func TestRegisterWithCount(t *testing.T) {
 		registrationFunc func(tasks.Task, bool)
 	}
 
-	var expectedRegisteredTaskCount int
-	if runtime.GOOS == "windows" { //we don't register InfraConfigValidateJMX in windows due to bug
-		expectedRegisteredTaskCount = 6
-	} else {
-		expectedRegisteredTaskCount = 7
-	}
+	expectedRegisteredTaskCount := 7
 
 	tests := []struct {
 		name      string
@@ -70,12 +65,7 @@ func TestRegisterWith(t *testing.T) {
 		InfraConfigIntegrationsValidate{fileReader: os.Open},
 		InfraConfigIntegrationsMatch{runtimeOS: runtime.GOOS},
 		InfraConfigIntegrationsValidateJson{},
-	}
-
-	if runtime.GOOS != "windows" { //we don't register InfraConfigValidateJMX in windows due to bug
-		expectedRegisteredTasks = append(expectedRegisteredTasks, InfraConfigValidateJMX{
-			mCmdExecutor: tasks.MultiCmdExecutor,
-		})
+		InfraConfigValidateJMX{mCmdExecutor: tasks.MultiCmdExecutor},
 	}
 
 	tests := []struct {

--- a/tasks/infra/config/validateJMX.go
+++ b/tasks/infra/config/validateJMX.go
@@ -232,7 +232,7 @@ func (p InfraConfigValidateJMX) checkJMXServer(detectedConfig JmxConfig) error {
 		//The first argument passed to exec.Command is the name of an executable (somefile.exe) and "echo" is not. To use shell commands, call the shell executable, and pass in the built-in command (and parameters)
 		cmd1 = tasks.CmdWrapper{
 			Cmd:  "cmd.exe",
-			Args: []string{"/C", "echo *:type=*,name=*"},
+			Args: []string{"/C", "echo", "*:type=*,name=*"},
 		}
 	} else {
 		cmd1 = tasks.CmdWrapper{

--- a/tasks/infra/config/validateJMX.go
+++ b/tasks/infra/config/validateJMX.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 
 	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
@@ -224,17 +225,31 @@ func processJMXFiles(jmxConfigPair *IntegrationFilePair) (JmxConfig, error) {
 }
 
 func (p InfraConfigValidateJMX) checkJMXServer(detectedConfig JmxConfig) error {
-
 	// echo "*:type=*,name=*" | nrjmx -hostname 127.0.0.1 -port 9999 --verbose true // basic command that returns all the things
 	// this queries for all beans, and givens back all types and all names
-	cmd1 := tasks.CmdWrapper{
-		Cmd:  "echo",
-		Args: []string{"*:type=*,name=*"},
+	var cmd1 tasks.CmdWrapper
+	if runtime.GOOS == "windows" {
+		//The first argument passed to exec.Command is the name of an executable (somefile.exe) and "echo" is not. To use shell commands, call the shell executable, and pass in the built-in command (and parameters)
+		cmd1 = tasks.CmdWrapper{
+			Cmd:  "cmd.exe",
+			Args: []string{"/C", "echo *:type=*,name=*"},
+		}
+	} else {
+		cmd1 = tasks.CmdWrapper{
+			Cmd:  "echo",
+			Args: []string{"*:type=*,name=*"},
+		}
 	}
 
 	jmxArgs := buildNrjmxArgs(detectedConfig)
+	var nrjmxCmd string
+	if runtime.GOOS == "windows" {
+		nrjmxCmd = `C:\Program Files\New Relic\nrjmx\nrjmx` //backticks to escape backslashes
+	} else {
+		nrjmxCmd = "nrjmx"
+	}
 	cmd2 := tasks.CmdWrapper{
-		Cmd:  "nrjmx", // note we're using nrjmx here instead of nr-jmx, nrjmx is the raw connect to JMX command while nr-jmx is the wrapper that queries based on collection files
+		Cmd:  nrjmxCmd, // note we're using nrjmx here instead of nr-jmx, nrjmx is the raw connect to JMX command while nr-jmx is the wrapper that queries based on collection files
 		Args: jmxArgs,
 	}
 


### PR DESCRIPTION
# Issue
This PR addresses the issue listed and described here: https://github.com/newrelic/newrelic-diagnostics-cli/issues/1

The first part of this cmd (right before the pipe) fails in windows `echo "*:type=*,name=*" | nrjmx -hostname 127.0.0.1 -port 9999 --verbose true` with the error `"echo": executable file not found`
This makes sense because we are using the go built-in function exec.Command (https://golang.org/pkg/os/exec/#Command), which expects to take the name of an executable as the first parameter followed by a list of arguments that get passed to that executable `func Command(name string, arg ...string)`. 

So our cmd above runs like this: `exec.Command("echo", ":type=*,name=*")`
However, "echo" is not an executable but built-in command in Powershell.


# Goals
1. Get Infra/Config/ValidateJMX to run in Windows without throwing an error for "echo: executable not found"
2. Add Infra/Env/NrjmxMbeans task to the list of tasks that run in Windows

# Implementation Details

1. To bypass the error in ValidateJMX, I am passing `cmd.exe` (which is the windows shell executable) as the first argument passed to exec.Command, and then, I am passing the built-in commands and parameters:
`exec.Command("cmd.exec", "/C", "echo", "*:type=*,name=*")`
Based on windows documentation:  `/C`  Carries out the command specified by string and then terminates

2. Because NrjmxMbeans task was also relying on running "echo" as the first argument passed in `exec.Command`, I had to make similar adjustments as the one above.

# How to Test
To tests these tasks, you should checkout into this branch and build the windows binary `GOOS=Windows go build`. Then you can run it on a windows vm that has installed the JMX integration for windows: https://docs.newrelic.com/docs/integrations/host-integrations/host-integrations-list/jmx-monitoring-integration#windows-install
No need to enable jmx metrics in a java app to see this task in action because as soon as nrdiag detects the new relic configuration file for jmx, infra/Config/ValidateJMX will run, and you will not see "echo" cmd fail anymore. At most you'll see the status.Failure with the summary: cannot connect to JMX server. And that is because you have not configured your jmx server to listen to the same port that is listed in the jmx config file.
Now, if you do want to be able to run infra/Env/NrjmxMbeans, in that case, you will have to enable jmx metrics because this task only runs after ValidateJMX task has succeeded at connecting to a jmx server. This is an example of how I enabled jmx metrics for my java app:

```
java-jar -Dcom.sun.management.jmxremote.password.file=jmxremote.password-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=true-Dcom.sun.management.jmxremote.port=9010-Dcom.sun.management.jmxremote.ssl=false -pathtoyourapp.jar
```
