### PR TITLE
moved files from old NR DIAG tasks into diagnostics_cli tasks.  Chang…

### DIFF
--- a/dockerHelper_test.go
+++ b/dockerHelper_test.go
@@ -51,9 +51,9 @@ func CreateDockerfile(imageName string, dockerFROM string, dockerCMD string, doc
 	baseWindowsDockerFrom := []string{
 		"FROM mcr.microsoft.com/windows/servercore:ltsc2019",
 		`SHELL ["powershell"]`,
-		"RUN NET USER nradmin /add",
-		"RUN NET LOCALGROUP administrators /add nradmin",
-		"USER nradmin",
+		"RUN NET USER nrdiagadmin /add",
+		"RUN NET LOCALGROUP administrators /add nrdiagadmin",
+		"USER nrdiagadmin",
 	}
 
 	baseDockerApp := []string{

--- a/tasks/compatibilityVars/versions.go
+++ b/tasks/compatibilityVars/versions.go
@@ -1,0 +1,87 @@
+package compatibilityVars
+
+var RubyVersionAgentSupportability = map[string][]string{
+	//the keys are the ruby version and the values are the agent versions that support that specific version
+	"2.7":   []string{"6.9.0.363+"},
+	"2.6":   []string{"5.7.0.350+"},
+	"2.5":   []string{"4.8.0.341+"},
+	"2.4":   []string{"3.18.0.329+"},
+	"2.3":   []string{"3.9.9.275+"},
+	"2.2":   []string{"3.9.9.275+"},
+	"2.1":   []string{"3.9.9.275+"},
+	"2.0":   []string{"3.9.6.257+"},
+	"1.9.3": []string{"3.9.6.257-3.18.1.330"},
+	"1.9.2": []string{"3.9.6.257-3.18.1.330"},
+	"1.8.7": []string{"3.9.6.257-3.18.1.330"},
+}
+
+var PythonVersionAgentSupportability = map[string][]string{
+	//the keys are the python version and the values are the agent versions that support that specific version
+	"3.8": []string{"5.2.3.131+"},
+	"3.7": []string{"3.4.0.95+"},
+	"3.6": []string{"2.80.0.60+"},
+	"3.5": []string{"2.78.0.57+"},
+	"3.4": []string{"2.42.0.35-4.20.0.120"},
+	"3.3": []string{"2.42.0.35-3.4.0.95"},
+	"2.7": []string{"2.42.0.35+"},
+	"2.6": []string{"2.42.0.35-3.4.0.95"},
+}
+
+/*
+	List of supported JRE distributions
+	The keys to this map are used verbatim to generate
+	a regular expression in `extractVendorFromJavaExecutable`
+	They should exactly match how they appear in the output
+	of `java -version.`
+
+	Any vendors not found in this map will be flagged as
+	unsupported. Known unsupported vendors can be called out
+	explicitly by using an empty slice of compatibility
+	requirements.
+
+
+*/
+
+var SupportedJavaVersions = map[string][]string{
+	// supported vendors
+	"OpenJDK":    []string{"1.7-1.9.*", "7-14.*"},
+	"HotSpot":    []string{"1.7-1.9.*", "7-14.*"},
+	"JRockit":    []string{"1-1.6.0.50"},
+	"Coretto":    []string{"1.8-1.9.*", "8-11.*"},
+	"Zulu":       []string{"1.8-1.9.*", "8-12.*"},
+	"IBM":        []string{"1.7-1.8.*", "7-8.*"},
+	"Oracle":     []string{"1.5.*", "5.0.*"},
+	"Zing":       []string{"1.8-1.9.*", "8-11.*"},
+	"OpenJ9":     []string{"1.8-1.9.*", "8-13.*"},
+	"Dragonwell": []string{"1.8-1.9.*", "8-11.*"},
+}
+
+//Supported only with Java agent 4.3.x:
+var SupportedForJavaAgent4 = map[string][]string{
+	"Apple":   []string{"1.6.*", "6.*"},
+	"IBM":     []string{"1.6.*", "6.*"},
+	"HotSpot": []string{"1.6.*", "6.*"},
+}
+
+var NodeSupportedVersions = map[string][]string{
+	"12": []string{"6.0.0+"},
+	"10": []string{"4.6.0+"},
+}
+
+var DotnetFrameworkSupportedVersions = map[string][]string{
+	"4.7": []string{"7.0.0+"},
+	"4.6": []string{"7.0.0+"},
+	"4.5": []string{"7.0.0+"},
+	"4.0": []string{"6.*"}, //TODO: check if these last two need to be more specific. Example: []string{"4.0.0-6.*"}
+	"3.5": []string{"6.*"},
+	//Doc says .NET Framework 3.0 and 2.0 are no longer supported as September 2020:https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
+}
+
+//.NET Core 2.0 or higher is supported by the New Relic .NET agent version 6.19 or higher
+var DotnetCoreSupportedVersions = map[string][]string{
+	"3.1": []string{"6.19.0+"},
+	"3.0": []string{"6.19.0+"},
+	"2.2": []string{"6.19.0+"},
+	"2.1": []string{"6.19.0+"},
+	"2.0": []string{"6.19.0+"},
+}

--- a/tasks/compatibilityVars/versions.go
+++ b/tasks/compatibilityVars/versions.go
@@ -78,6 +78,7 @@ var DotnetFrameworkSupportedVersions = map[string][]string{
 }
 
 //.NET Core 2.0 or higher is supported by the New Relic .NET agent version 6.19 or higher
+
 var DotnetCoreSupportedVersions = map[string][]string{
 	"3.1": []string{"6.19.0+"},
 	"3.0": []string{"6.19.0+"},
@@ -85,3 +86,5 @@ var DotnetCoreSupportedVersions = map[string][]string{
 	"2.1": []string{"6.19.0+"},
 	"2.0": []string{"6.19.0+"},
 }
+
+//https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core#net-version

--- a/tasks/compatibilityVars/versions.go
+++ b/tasks/compatibilityVars/versions.go
@@ -80,11 +80,12 @@ var DotnetFrameworkSupportedVersions = map[string][]string{
 //.NET Core 2.0 or higher is supported by the New Relic .NET agent version 6.19 or higher
 
 var DotnetCoreSupportedVersions = map[string][]string{
-	"3.1": []string{"6.19.0+"},
-	"3.0": []string{"6.19.0+"},
-	"2.2": []string{"6.19.0+"},
-	"2.1": []string{"6.19.0+"},
-	"2.0": []string{"6.19.0+"},
+	"5.0": []string{"8.35.0+"},
+	"3.1": []string{"8.21.34.0+"},
+	"3.0": []string{"8.21.34.0+"},
+	"2.2": []string{"8.19.353.0+"},
+	"2.1": []string{"8.19.353.0+"},
+	"2.0": []string{"8.19.353.0+"},
 }
 
 //https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-core#net-version

--- a/tasks/compatibilityVars/versions.go
+++ b/tasks/compatibilityVars/versions.go
@@ -68,12 +68,17 @@ var NodeSupportedVersions = map[string][]string{
 	"10": []string{"4.6.0+"},
 }
 
+// .NET framework as keys and .NET agent as values
 var DotnetFrameworkSupportedVersions = map[string][]string{
 	"4.7": []string{"7.0.0+"},
-	"4.6": []string{"7.0.0+"},
+	"4.6": []string{"7.0.0+"}, //should be inclusive of version such as 4.6.1
 	"4.5": []string{"7.0.0+"},
-	"4.0": []string{"6.*"}, //TODO: check if these last two need to be more specific. Example: []string{"4.0.0-6.*"}
-	"3.5": []string{"6.*"},
+}
+
+var DotnetFrameworkOldVersions = map[string][]string{
+	//To instrument applications running on .NET Framework version 4.0 and lower, you must run a version of the New Relic .NET agent earlier than 7.0
+	"4.0": []string{"5.1.*-6.*"}, //5.0 and lower are EOL versions
+	"3.5": []string{"5.1.*-6.*"},
 	//Doc says .NET Framework 3.0 and 2.0 are no longer supported as September 2020:https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework
 }
 

--- a/tasks/compatibilityVars/versions_test.go
+++ b/tasks/compatibilityVars/versions_test.go
@@ -1,1 +1,0 @@
-package compatibilityVars

--- a/tasks/compatibilityVars/versions_test.go
+++ b/tasks/compatibilityVars/versions_test.go
@@ -1,0 +1,1 @@
+package compatibilityVars

--- a/tasks/dotnet/env/versions_windows.go
+++ b/tasks/dotnet/env/versions_windows.go
@@ -57,7 +57,7 @@ func (t DotNetEnvVersions) Execute(options tasks.Options, upstream map[string]ta
 	}
 }
 
-//Queries the regestry for .Net version and translates that to a more friendly form
+//Queries the registry for .Net version and translates that to a more friendly form
 func checkNetVersions() (versions []string) {
 	v4OrAbove := false
 	regKey, err := registry.OpenKey(registry.LOCAL_MACHINE, netVersionBaseLoc, registry.ENUMERATE_SUB_KEYS|registry.QUERY_VALUE)

--- a/tasks/dotnet/requirements/net_agent_ver_val_windows.go
+++ b/tasks/dotnet/requirements/net_agent_ver_val_windows.go
@@ -44,89 +44,73 @@ func (t DotnetRequirementsNetTargetAgentVerValidate) Execute(options tasks.Optio
 		}
 	}
 
-	agentVer := upstream["DotNet/Agent/Version"].Summary
-	dotNetAgentVersion, good := tasks.ParseVersion(agentVer) //Examples of how this string looks like: 8.30.0.0 or 8.3.360.0. TODO: will our compatibilityVars.DotnetFrameworkSupportedVersions complain if we are passing a 4 digit string rather than something like 7.0.0???
-	if good != nil {
+	agentVersion, ok := upstream["DotNet/Agent/Version"].Payload.(string)//Examples of how this string looks like: 8.30.0.0 or 8.3.360.0
+
+	if !ok {
 		return tasks.Result{
-			Status:  tasks.Error,
-			Summary: "Error parsing Target .Net Agent version " + good.Error(),
-		}
-	}
-	dotNetVersions := strings.Replace(upstream["DotNet/Env/TargetVersion"].Summary, " ", "", -1) //gets a string containing multiple dotnet versions
-	dotNetVersionsList := strings.Split(dotNetVersions, ",")
-
-	//The .Net target version check can pick up multiple config files
-	//If there are multiple versions of .Net targeted it indicates an issue
-
-	//we arbitrarily grab the first because we assume they are all the same versions
-	//UPDATE going through and checking compatibility for each dotnet framework version
-	var compatibleVersions []string
-	var incompatibleVersions []string
-	var warningMessage string
-	var successMessage string
-
-	if !checkConsistentTargets(dotNetVersionsList) {
-		//TODO: check if any of them is not compatible with the agent, otherwise no need for a warning. Here is an example ticket of how we get multiple versions yet all of them are compatible with the agent:https://newrelic.zendesk.com/agent/tickets/414788
-		//UPDATE: this is just to return a warning if multiple dotnet versions are detected
-		warningMessage += "Detected multiple target .NET versions.\nThe target .NET versions detected as: " + dotNetVersions + " and Agent version detected as: " + agentVer + "\n"
-
-	}
-	for _, version := range dotNetVersionsList {
-
-		//check if version is in the supported framework version
-		requiredAgentVersions, isTargetVersionSupported := compatibilityVars.DotnetFrameworkSupportedVersions[version]
-		if !isTargetVersionSupported {
-			return tasks.Result{
-				Status:  tasks.Failure,
-				Summary: "The detected Target .NET version is not supported by any .NET agent version: " + version,
-			}
-		}
-
-		//check if the dotnetTarget version can be parsed
-		/*dotnetTargetVersion, ok := tasks.ParseVersion(version)
-		if ok != nil {
-			return tasks.Result{
-				Status:  tasks.Error,
-				Summary: "Error parsing Target .Net version " + ok.Error(),
-			}
-		}*/
-
-		//check if the dotnet agent version and dotnet framework version are compatible
-
-		isDotnetAgentVersionCompatible, err := dotNetAgentVersion.CheckCompatibility(requiredAgentVersions)
-		if err != nil {
-			var errMsg string = err.Error()
-			log.Debug(errMsg)
-			return tasks.Result{
-				Status:  tasks.Error,
-				Summary: fmt.Sprintf("We ran into an error while parsing your current agent version %s. %s", agentVer, errMsg),
-			}
-		}
-		if isDotnetAgentVersionCompatible {
-			compatibleVersions = append(compatibleVersions, version)
-			successMessage += "Compatible Version detected: " + version + "\n"
-		} else {
-			incompatibleVersions = append(incompatibleVersions, version)
-			warningMessage += "Incompatible Version detected: " + version + "\n"
+			Status: tasks.None,
+			Summary: "Type Assertion failure from upstream task DotNet/Agent/Version in DotNet/Requirements/NetTargetAgentVersionValidate",
 		}
 	}
 
-	if len(incompatibleVersions) > 0 && len(compatibleVersions) > 0 {
+	frameworkVersions, ok := upstream["DotNet/Env/TargetVersion"].Payload.([]string) //gets a slice containing multiple dotnet versions: .Net Targets detected as 4.6,4.6,4.6,4.7.2,4.6
+
+	if !ok{
 		return tasks.Result{
-			Status:  tasks.Warning,
-			Summary: warningMessage + successMessage,
+			Status: tasks.None,
+			Summary: "Type Assertion failure from upstream task DotNet/Env/TargetVersion in DotNet/Requirements/NetTargetAgentVersionValidate",
 		}
 	}
-	if len(incompatibleVersions) > 0 && len(compatibleVersions) == 0 {
+
+	var unsupportedFrameworkVersions []string
+	var incompatibleFrameworkVersions []string
+
+	for _, frameworkVer := range frameworkVersions {
+		isFrameworkVerSupported, requiredAgentVersions := checkFrameworkVerIsSupported(frameworkVer)
+		!isFrameworkVerSupported{
+			unsupportedFrameworkVersions = append(unsupportedFrameworkVersions, frameworkVer)
+			continue
+		}
+		isCompatibleWithAgent:= checkCompatibilityWithAgentVer(requiredAgentVersions, agentVersion)
+		!isCompatibleWithAgent{
+			incompatibleFrameworkVersions = append(incompatibleFrameworkVersions, frameworkVer)
+		}		
+	}
+
+	var failureSummary string
+	if len(unsupportedFrameworkVersions) > 0 {
+		warningSummary += fmt.Sprintf("We found a Target Framework version(s) that is not supported by the New Relic .NET agent: %s", strings.Join(unsupportedFrameworkVersions, ", "))
+	}
+	if len(incompatibleFrameworkVersions) > 0 {
+		warningSummary += fmt.Sprintf("We found that your New Relic .NET agent version %s is not compatible with the following Target .NET version(s): %s", agentVersion, strings.Join(incompatibleFrameworkVersions, ", "))
+	}
+
+	legacyDocURL := "https://docs.newrelic.com/docs/agents/net-agent/troubleshooting/technical-support-net-framework-40-or-lower"
+	requirementsDocURL := "https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework"
+
+	if len(failureSummary) > 0 {
 		return tasks.Result{
-			Status:  tasks.Failure,
-			Summary: warningMessage,
+			Status: tasks.Failure,
+			Summary: failureSummary,
+			URL: requirementsDocURL + "\n" + legacyDocURL,
 		}
 	}
+
 	return tasks.Result{
-		Status:  tasks.Success,
-		Summary: successMessage,
+		Status: tasks.Success,
+		Summary: fmt.Sprintf("Your .NET agent version % is fully compatible with the following found Target .NET version(s): %s", agentVersion, strings.Join(frameworkVersions, ", "))
 	}
+
+}
+
+func checkFrameworkVerIsSupported(frameworkVer) (bool, []string){
+	requiredAgentVersions, isFrameworkVerSupported := compatibilityVars.DotnetFrameworkSupportedVersions[frameworkVer]
+	if isFrameworkVerSupported{
+		return true, requiredAgentVersions
+	}
+	requiredLegacyAgentVersions, isOldFrameworkVerSupported := compatibilityVars.DotnetFrameworkOldVersions[frameworkVer]
+
+	return isOldFrameworkVerSupported, requiredLegacyAgentVersions		
 }
 
 func checkDependencies(upstream map[string]tasks.Result) (bool, string) {
@@ -142,17 +126,4 @@ func checkDependencies(upstream map[string]tasks.Result) (bool, string) {
 		return false, "Did not detect .Net Agent version, this check did not run"
 	}
 	return true, ""
-}
-
-func checkConsistentTargets(targetSplitList []string) bool {
-	if len(targetSplitList) > 1 {
-		for _, v := range targetSplitList {
-			for _, subV := range targetSplitList {
-				if v != subV {
-					return false
-				}
-			}
-		}
-	}
-	return true
 }

--- a/tasks/dotnet/requirements/net_agent_ver_val_windows.go
+++ b/tasks/dotnet/requirements/net_agent_ver_val_windows.go
@@ -4,9 +4,9 @@ import (
 	"fmt"
 	"strings"
 
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks/compatibilityVars"
-	log "go.datanerd.us/p/support-tools/nr-diagnostics/logger"
 )
 
 // DotnetRequirementsNetTargetAgentVerValidate - This struct defines the task

--- a/tasks/dotnet/requirements/net_agent_ver_val_windows.go
+++ b/tasks/dotnet/requirements/net_agent_ver_val_windows.go
@@ -67,12 +67,12 @@ func (t DotnetRequirementsNetTargetAgentVerValidate) Execute(options tasks.Optio
 
 	for _, frameworkVer := range frameworkVersions {
 		isFrameworkVerSupported, requiredAgentVersions := checkFrameworkVerIsSupported(frameworkVer)
-		!isFrameworkVerSupported{
+		if !isFrameworkVerSupported{
 			unsupportedFrameworkVersions = append(unsupportedFrameworkVersions, frameworkVer)
 			continue
 		}
 		isCompatibleWithAgent:= checkCompatibilityWithAgentVer(requiredAgentVersions, agentVersion)
-		!isCompatibleWithAgent{
+		if !isCompatibleWithAgent{
 			incompatibleFrameworkVersions = append(incompatibleFrameworkVersions, frameworkVer)
 		}		
 	}

--- a/tasks/dotnet/requirements/net_agent_ver_val_windows_test.go
+++ b/tasks/dotnet/requirements/net_agent_ver_val_windows_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 	})
 	Describe("Explain()", func() {
 		It("Should return Explain string", func() {
-			Expect(p.Explain()).To(Equal("Check application's .NET version compatibility with New Relic .NET agent"))
+			Expect(p.Explain()).To(Equal("Check application's .NET Framework version compatibility with New Relic .NET agent"))
 		})
 	})
 	Describe("Dependencies()", func() {
@@ -39,6 +39,7 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 		JustBeforeEach(func() {
 			result = p.Execute(options, upstream)
 		})
+
 		Context("With unsuccessful upstream agent detection", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
@@ -55,7 +56,7 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
-					"DotNet/Agent/Installed":           tasks.Result{Status: tasks.Success},
+					"DotNet/Agent/Installed":   tasks.Result{Status: tasks.Success},
 					"DotNet/Env/TargetVersion": tasks.Result{Status: tasks.Failure},
 				}
 			})
@@ -70,9 +71,9 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
-					"DotNet/Agent/Installed":           tasks.Result{Status: tasks.Success},
+					"DotNet/Agent/Installed":   tasks.Result{Status: tasks.Success},
 					"DotNet/Env/TargetVersion": tasks.Result{Status: tasks.Info},
-					"DotNet/Agent/Version":             tasks.Result{Status: tasks.Failure},
+					"DotNet/Agent/Version":     tasks.Result{Status: tasks.Failure},
 				}
 			})
 			It("Should return None status", func() {
@@ -82,14 +83,14 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 				Expect(result.Summary).To(Equal("Did not detect .Net Agent version, this check did not run"))
 			})
 		})
-		Context("With valid versions", func() {
+		Context("With unsupported Dotnet Framework Version", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
 					"DotNet/Env/TargetVersion": tasks.Result{
 						Status:  tasks.Info,
-						Summary: "4.5",
+						Summary: "3.0",
 					},
 					"DotNet/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
@@ -97,21 +98,43 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 					},
 				}
 			})
-			It("Should return Success status", func() {
-				Expect(result.Status).To(Equal(tasks.Success))
+			It("Should return Failure status", func() {
+				Expect(result.Status).To(Equal(tasks.Failure))
 			})
 			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal(".Net target and Agent version compatible. .Net Target detected as 4.5, Agent version detected as 7.0.2.0"))
+				Expect(result.Summary).To(Equal("The detected Target .NET version is not supported by any .NET agent version: 3.0"))
 			})
 		})
-		Context("With multiple dotnet target versions detected", func() {
+		Context("With error parsing dotnet framework", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
 					"DotNet/Env/TargetVersion": tasks.Result{
 						Status:  tasks.Info,
-						Summary: "4.5, 3.5",
+						Summary: "4.0",
+					},
+					"DotNet/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Summary: "hot dogs and baloney",
+					},
+				}
+			})
+			It("Should return Error status", func() {
+				Expect(result.Status).To(Equal(tasks.Error))
+			})
+			It("Should return expected summary", func() {
+				Expect(result.Summary).To(Equal("Error parsing Target .Net Agent version Unable to convert hot dogs and baloney to an integer"))
+			})
+		})
+		Context("With multiple target frameworks and only one is supported", func() {
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
+					"DotNet/Env/TargetVersion": tasks.Result{
+						Status:  tasks.Info,
+						Summary: "4.5,4.0",
 					},
 					"DotNet/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
@@ -123,76 +146,10 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 				Expect(result.Status).To(Equal(tasks.Warning))
 			})
 			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal("Detected multiple versions for .Net Target or unable to determine targets. .Net Targets detected as 4.5,3.5, Agent version detected as 7.0.2.0"))
+				Expect(result.Summary).To(Equal("Detected multiple target .NET versions.\nThe target .NET versions detected as: 4.5,4.0 and Agent version detected as: 7.0.2.0\nIncompatible Version detected: 4.0\nCompatible Version detected: 4.5\n"))
 			})
 		})
-		Context("With error parsing dotnet target version", func() {
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
-					"DotNet/Env/TargetVersion": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "superman",
-					},
-					"DotNet/Agent/Version": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "7.0.2.0",
-					},
-				}
-			})
-			It("Should return Error status", func() {
-				Expect(result.Status).To(Equal(tasks.Error))
-			})
-			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal("Error parsing Target .Net version Unable to convert superman to an integer"))
-			})
-		})
-		Context("With unsupported dotnet target version", func() {
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
-					"DotNet/Env/TargetVersion": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "1.9",
-					},
-					"DotNet/Agent/Version": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "7.0.2.0",
-					},
-				}
-			})
-			It("Should return Failure status", func() {
-				Expect(result.Status).To(Equal(tasks.Failure))
-			})
-			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal("Target .Net version detected as below 2.0. This version of .Net is not supported by any agent versions"))
-			})
-		})
-		Context("With supported dotnet target version 2.0", func() {
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
-					"DotNet/Env/TargetVersion": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "2.0",
-					},
-					"DotNet/Agent/Version": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "6.0.2.0",
-					},
-				}
-			})
-			It("Should return Success status", func() {
-				Expect(result.Status).To(Equal(tasks.Success))
-			})
-			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal(".Net target and Agent version compatible. .Net Target detected as 2.0, Agent version detected as 6.0.2.0"))
-			})
-		})
-		Context("With error parsing agent version", func() {
+		Context("With success for one target framework version", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
@@ -203,29 +160,7 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 					},
 					"DotNet/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
-						Summary: "I am batmat!",
-					},
-				}
-			})
-			It("Should return Error status", func() {
-				Expect(result.Status).To(Equal(tasks.Error))
-			})
-			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal("Error parsing Agent version"))
-			})
-		})
-		Context("With compatible versions multiple dotnet targets", func() {
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
-					"DotNet/Env/TargetVersion": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "4.5, 4.5",
-					},
-					"DotNet/Agent/Version": tasks.Result{
-						Status:  tasks.Info,
-						Summary: "6.18",
+						Summary: "7.0.2.0",
 					},
 				}
 			})
@@ -233,17 +168,39 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 				Expect(result.Status).To(Equal(tasks.Success))
 			})
 			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal(".Net target and Agent version compatible. .Net Target detected as 4.5, Agent version detected as 6.18"))
+				Expect(result.Summary).To(Equal("Compatible Version detected: 4.5\n"))
 			})
 		})
-		Context("With invalid combination of versions", func() {
+		Context("With success for multiple target framework versions", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
 					"DotNet/Env/TargetVersion": tasks.Result{
 						Status:  tasks.Info,
-						Summary: "4",
+						Summary: "4.5, 4.6",
+					},
+					"DotNet/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Summary: "7.0.2.0",
+					},
+				}
+			})
+			It("Should return Success status", func() {
+				Expect(result.Status).To(Equal(tasks.Success))
+			})
+			It("Should return expected summary", func() {
+				Expect(result.Summary).To(Equal("Compatible Version detected: 4.5\nCompatible Version detected: 4.6\n"))
+			})
+		})
+		Context("With multiple dotnet target versions detected and neither are compatible", func() {
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
+					"DotNet/Env/TargetVersion": tasks.Result{
+						Status:  tasks.Info,
+						Summary: "3.5, 4.0",
 					},
 					"DotNet/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
@@ -255,9 +212,54 @@ var _ = Describe("Dotnet/Requirements/NetTargetAgentVerValidate", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
 			})
 			It("Should return expected summary", func() {
-				Expect(result.Summary).To(Equal("App detected as targeting a version of .Net below 4.5 with an Agent version of 7 or above. .Net Target detected as 4, Agent version detected as 7.0.2.0"))
+				Expect(result.Summary).To(Equal("Detected multiple target .NET versions.\nThe target .NET versions detected as: 3.5,4.0 and Agent version detected as: 7.0.2.0\nIncompatible Version detected: 3.5\nIncompatible Version detected: 4.0\n"))
 			})
 		})
+		/*
+			Context("With compatible versions multiple dotnet targets", func() {
+				BeforeEach(func() {
+					options = tasks.Options{}
+					upstream = map[string]tasks.Result{
+						"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
+						"DotNet/Env/TargetVersion": tasks.Result{
+							Status:  tasks.Info,
+							Summary: "4.5, 4.5",
+						},
+						"DotNet/Agent/Version": tasks.Result{
+							Status:  tasks.Info,
+							Summary: "6.18",
+						},
+					}
+				})
+				It("Should return Success status", func() {
+					Expect(result.Status).To(Equal(tasks.Success))
+				})
+				It("Should return expected summary", func() {
+					Expect(result.Summary).To(Equal(".Net target and Agent version compatible. .Net Target detected as 4.5, Agent version detected as 6.18"))
+				})
+			})
+			Context("With invalid combination of versions", func() {
+				BeforeEach(func() {
+					options = tasks.Options{}
+					upstream = map[string]tasks.Result{
+						"DotNet/Agent/Installed": tasks.Result{Status: tasks.Success},
+						"DotNet/Env/TargetVersion": tasks.Result{
+							Status:  tasks.Info,
+							Summary: "4",
+						},
+						"DotNet/Agent/Version": tasks.Result{
+							Status:  tasks.Info,
+							Summary: "7.0.2.0",
+						},
+					}
+				})
+				It("Should return Failure status", func() {
+					Expect(result.Status).To(Equal(tasks.Failure))
+				})
+				It("Should return expected summary", func() {
+					Expect(result.Summary).To(Equal("App detected as targeting a version of .Net below 4.5 with an Agent version of 7 or above. .Net Target detected as 4, Agent version detected as 7.0.2.0"))
+				})
+			})*/
 
 	})
 })

--- a/tasks/dotnetcore/env/versions.go
+++ b/tasks/dotnetcore/env/versions.go
@@ -1,9 +1,9 @@
 package env
 
 import (
-	"os"
 	"errors"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -51,7 +51,6 @@ func (t DotNetCoreEnvVersions) Execute(options tasks.Options, upstream map[strin
 
 	if versions == nil || len(versions) < 1 {
 		if checkVersionsErrorDetails != nil || checkVersionErrorCount > 0 {
-			logger.Debug("DotNetCoreVersions - Error determining the version .NET Core installed. There were", checkVersionErrorCount, "errors. Please check previous log entries for other errors. The last error seen was: ", checkVersionsErrorDetails.Error())
 			result.Status = tasks.Error
 			result.Summary = "Error determining the version .NET Core installed."
 			return result
@@ -85,7 +84,7 @@ func checkVersions(envVars map[string]string) (versions []string, countErrors in
 	//dotnet --version will Display .NET Core SDK version. Ex: 5.0.101
 	version, err := tasks.CmdExecutor("dotnet", "--version")
 
-	if err != nil{
+	if err != nil {
 		countErrors++
 		logger.Debug("unable to get the version with the cmd dotnet --version:", err)
 	} else {
@@ -96,7 +95,7 @@ func checkVersions(envVars map[string]string) (versions []string, countErrors in
 	dirsToRead, retErr := buildDirsToRead(envVars)
 	if retErr != nil {
 		countErrors++
-		return nil, countErrors, retErr
+		return []string{}, countErrors, retErr
 	}
 
 	logger.Debug("DotNetCoreVersions - dirs to read:", dirsToRead)

--- a/tasks/dotnetcore/env/versions.go
+++ b/tasks/dotnetcore/env/versions.go
@@ -81,11 +81,15 @@ func (t DotNetCoreEnvVersions) Execute(options tasks.Options, upstream map[strin
 func checkVersions(envVars map[string]string) (versions []string, countErrors int, retErr error) {
 	countErrors = 0
 
-	// first check if version is in env vars
-	versionFromEnvVars := envVars["DOTNET_SDK_VERSION"]
-	if versionFromEnvVars != "" {
-		logger.Debug("DotNetCoreVersions - found .NET Core version in DOTNET_SDK_VERSION Env Var")
-		return append(versions, versionFromEnvVars), countErrors, retErr
+	// first check if version is accesible through the cmdline
+	//dotnet --version will Display .NET Core SDK version. Ex: 5.0.101
+	version, err := tasks.CmdExecutor("dotnet", "--version")
+
+	if err != nil{
+		countErrors++
+		logger.Debug("unable to get the version with the cmd dotnet --version:", err)
+	} else {
+		return []string{string(version)}, countErrors, nil
 	}
 
 	// check dirs

--- a/tasks/dotnetcore/requirements/netcore-version.go
+++ b/tasks/dotnetcore/requirements/netcore-version.go
@@ -2,6 +2,7 @@ package requirements
 
 import (
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks/compatibilityVars"
 )
 
 // DotNetCoreRequirementsNetCoreVersion - This task checks the .NET Core version against the .Net Core Agent requirements
@@ -56,7 +57,7 @@ func (t DotNetCoreRequirementsNetCoreVersion) Execute(options tasks.Options, ups
 func checkVersion(installedVersions []string) (result tasks.Result) {
 	for _, version := range installedVersions {
 		majorVer, _, _, _ := tasks.GetVersionSplit(version)
-		if majorVer >= 2 {
+		if majorVer >= compatibilityVars.DotnetCoreSupportedVersions {
 			result.Status = tasks.Success
 			result.Summary = ".NET Core 2.0 or higher detected."
 			return

--- a/tasks/dotnetcore/requirements/netcore-version.go
+++ b/tasks/dotnetcore/requirements/netcore-version.go
@@ -73,10 +73,9 @@ func (t DotNetCoreRequirementsNetCoreVersion) Execute(options tasks.Options, ups
 func checkCoreVersionsAreSupported(dotnetCoreInstalledVers []string) (bool, []string) {
 	var unsupportedVers []string
 	for _, coreVersion := range dotnetCoreInstalledVers {
-		majorVer, _, _, _ := tasks.GetVersionSplit(coreVersion)
-		majorVerToStr := strconv.Itoa(majorVer)
-
-		_, isPresent := compatibilityVars.DotnetCoreSupportedVersions[majorVerToStr]
+		majorVer, minorVer, _, _ := tasks.GetVersionSplit(coreVersion)
+		majorMinorVer := strconv.Itoa(majorVer) + "." + strconv.Itoa(minorVer)
+		_, isPresent := compatibilityVars.DotnetCoreSupportedVersions[majorMinorVer]
 
 		if !isPresent {
 			unsupportedVers = append(unsupportedVers, coreVersion)

--- a/tasks/java/jvm/vendorsVersions.go
+++ b/tasks/java/jvm/vendorsVersions.go
@@ -424,50 +424,48 @@ func extractVersionFromArgs(cmdLineArgs string) (version string) {
 func extractVendorFromArgs(cmdLineArgs string) (vendor string) {
 
 	//splitting on just space here would break when: Djava.vm.name=Java HotSpot(TM)
+
 	sliceCmdLineArgs := strings.Split(cmdLineArgs, " -")
 	for _, cmdLineArg := range sliceCmdLineArgs {
 		if strings.Contains(cmdLineArg, "java.vm.name") {
 			/* IBM J9 */
-			match, _ := regexp.MatchString(".*IBM.*", cmdLineArg)
-			if match {
+			if strings.Contains(cmdLineArg, "IBM") {
 				log.Debug("Detected IBM JVM")
 				vendor = "IBM"
 				return
 			}
 			/* IBM Classic VM */
-			match, _ = regexp.MatchString(".*Classic.*", cmdLineArg)
-			if match {
+			if strings.Contains(cmdLineArg, "Classic") {
 				log.Debug("Detected IBM Classic JVM")
 				vendor = "IBM"
 				return
 			}
-			match, _ = regexp.MatchString(".*HotSpot.*", cmdLineArg)
-			if match {
+
+			if strings.Contains(cmdLineArg, "HotSpot") {
 				log.Debug("Detected Hotspot JVM")
 				vendor = "HotSpot"
 				return
 			}
-			match, _ = regexp.MatchString(".*JRockit.*", cmdLineArg)
-			if match {
+
+			if strings.Contains(cmdLineArg, "JRockit") {
 				log.Debug("Detected JRockit JVM")
 				vendor = "JRockit"
 				return
 			}
 		}
 		if strings.Contains(cmdLineArg, "java.vm.vendor") {
-			match, _ := regexp.MatchString("Apple.*", cmdLineArg)
-			if match {
+			//cmlineArg would look something like this: -Djava.vm.vendor=Oracle Corporation
+
+			if strings.Contains(cmdLineArg, "Apple") {
 				log.Debug("Detected Apple JVM")
 				vendor = "Apple"
 				return
 			}
-			match, _ = regexp.MatchString(".*IBM.*", cmdLineArg)
-			if match {
+			if strings.Contains(cmdLineArg, "IBM") {
 				log.Debug("Detected IBM JVM")
 				vendor = "IBM"
 			}
-			match, _ = regexp.MatchString("Oracle.*", cmdLineArg)
-			if match && vendor != "HotSpot" {
+			if (strings.Contains(cmdLineArg, "Oracle")) && vendor != "HotSpot" {
 				log.Debug("Detected Oracle JVM")
 				vendor = "Oracle"
 			}

--- a/tasks/java/jvm/vendorsVersions.go
+++ b/tasks/java/jvm/vendorsVersions.go
@@ -33,7 +33,6 @@ type PIDInfo struct {
 type JavaJVMVendorsVersions struct {
 	findProcessByName func(string) ([]process.Process, error)
 	cmdExec           func(name string, arg ...string) ([]byte, error)
-	name              string
 	runtimeGOOS       string
 	getCmdLineArgs    func(process.Process) (string, error)
 }
@@ -413,7 +412,7 @@ func extractVersionFromArgs(cmdLineArgs string) (version string) {
 			return
 		/* e.g. -Djava.vm.version=Oracle JRockit(R) (R28.0.0-617-125986-1.6.0_17-20091215-2120-windows-x86_64, compiled mode) */
 		case strings.Contains(cmdLineArg, "java.vm.version"):
-			matchVendorString := regexp.MustCompile(".*([0-9]{1}\\.[0-9]{1}\\.[0-9]{1}[_0-9]{0,3}).*")
+			matchVendorString := regexp.MustCompile(`.*([0-9]{1}\.[0-9]{1}\.[0-9]{1}[_0-9]{0,3}).*`)
 			version = matchVendorString.FindStringSubmatch(cmdLineArg)[1]
 			return
 		}
@@ -468,7 +467,7 @@ func extractVendorFromArgs(cmdLineArgs string) (vendor string) {
 				vendor = "IBM"
 			}
 			match, _ = regexp.MatchString("Oracle.*", cmdLineArg)
-			if match == true && vendor != "HotSpot" {
+			if match && vendor != "HotSpot" {
 				log.Debug("Detected Oracle JVM")
 				vendor = "Oracle"
 			}

--- a/tasks/java/jvm/vendorsVersions.go
+++ b/tasks/java/jvm/vendorsVersions.go
@@ -5,10 +5,10 @@ import (
 	"regexp"
 	"strings"
 
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks/compatibilityVars"
 	"github.com/shirou/gopsutil/process"
-	log "go.datanerd.us/p/support-tools/nr-diagnostics/logger"
 )
 
 type supportabilityStatus int

--- a/tasks/java/jvm/vendorsVersions.go
+++ b/tasks/java/jvm/vendorsVersions.go
@@ -5,44 +5,11 @@ import (
 	"regexp"
 	"strings"
 
-	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks/compatibilityVars"
 	"github.com/shirou/gopsutil/process"
+	log "go.datanerd.us/p/support-tools/nr-diagnostics/logger"
 )
-
-/*
-	List of supported JRE distributions
-	The keys to this map are used verbatim to generate
-	a regular expression in `extractVendorFromJavaExecutable`
-	They should exactly match how they appear in the output
-	of `java -version.`
-
-	Any vendors not found in this map will be flagged as
-	unsupported. Known unsupported vendors can be called out
-	explicitly by using an empty slice of compatibility
-	requirements.
-
-*/
-var supportedVersions = map[string][]string{
-	// supported vendors
-	"OpenJDK":    []string{"1.7-1.9.*", "7-14.*"},
-	"HotSpot":    []string{"1.7-1.9.*", "7-14.*"},
-	"JRockit":    []string{"1-1.6.0.50"},
-	"Coretto":    []string{"1.8-1.9.*", "8-11.*"},
-	"Zulu":       []string{"1.8-1.9.*", "8-12.*"},
-	"IBM":        []string{"1.7-1.8.*", "7-8.*"},
-	"Oracle":     []string{"1.5.*", "5.0.*"},
-	"Zing":       []string{"1.8-1.9.*", "8-11.*"},
-	"OpenJ9":     []string{"1.8-1.9.*", "8-13.*"},
-	"Dragonwell": []string{"1.8-1.9.*", "8-11.*"},
-}
-
-//Supported only with Java agent 4.3.x:
-var supportedForJavaAgent4 = map[string][]string{
-	"Apple":   []string{"1.6.*", "6.*"},
-	"IBM":     []string{"1.6.*", "6.*"},
-	"HotSpot": []string{"1.6.*", "6.*"},
-}
 
 type supportabilityStatus int
 
@@ -66,6 +33,7 @@ type PIDInfo struct {
 type JavaJVMVendorsVersions struct {
 	findProcessByName func(string) ([]process.Process, error)
 	cmdExec           func(name string, arg ...string) ([]byte, error)
+	name              string
 	runtimeGOOS       string
 	getCmdLineArgs    func(process.Process) (string, error)
 }
@@ -383,11 +351,11 @@ func extractVendorFromJavaExecutable(execOutput string) (vendor string) {
 	}
 
 	uniqueVendors := map[string]interface{}{}
-	for v := range supportedVersions {
+	for v := range compatibilityVars.SupportedJavaVersions {
 		uniqueVendors[v] = struct{}{}
 	}
 
-	for v := range supportedForJavaAgent4 {
+	for v := range compatibilityVars.SupportedForJavaAgent4 {
 		uniqueVendors[v] = struct{}{}
 	}
 
@@ -445,7 +413,7 @@ func extractVersionFromArgs(cmdLineArgs string) (version string) {
 			return
 		/* e.g. -Djava.vm.version=Oracle JRockit(R) (R28.0.0-617-125986-1.6.0_17-20091215-2120-windows-x86_64, compiled mode) */
 		case strings.Contains(cmdLineArg, "java.vm.version"):
-			matchVendorString := regexp.MustCompile(".*([0-9]{1}\\.[0-9]{1}\\.[0-9]{1}[_0-9]{0,3}).*") //nolint
+			matchVendorString := regexp.MustCompile(".*([0-9]{1}\\.[0-9]{1}\\.[0-9]{1}[_0-9]{0,3}).*")
 			version = matchVendorString.FindStringSubmatch(cmdLineArg)[1]
 			return
 		}
@@ -457,48 +425,50 @@ func extractVersionFromArgs(cmdLineArgs string) (version string) {
 func extractVendorFromArgs(cmdLineArgs string) (vendor string) {
 
 	//splitting on just space here would break when: Djava.vm.name=Java HotSpot(TM)
-
 	sliceCmdLineArgs := strings.Split(cmdLineArgs, " -")
 	for _, cmdLineArg := range sliceCmdLineArgs {
 		if strings.Contains(cmdLineArg, "java.vm.name") {
 			/* IBM J9 */
-			if strings.Contains(cmdLineArg, "IBM") {
+			match, _ := regexp.MatchString(".*IBM.*", cmdLineArg)
+			if match {
 				log.Debug("Detected IBM JVM")
 				vendor = "IBM"
 				return
 			}
 			/* IBM Classic VM */
-			if strings.Contains(cmdLineArg, "Classic") {
+			match, _ = regexp.MatchString(".*Classic.*", cmdLineArg)
+			if match {
 				log.Debug("Detected IBM Classic JVM")
 				vendor = "IBM"
 				return
 			}
-
-			if strings.Contains(cmdLineArg, "HotSpot") {
+			match, _ = regexp.MatchString(".*HotSpot.*", cmdLineArg)
+			if match {
 				log.Debug("Detected Hotspot JVM")
 				vendor = "HotSpot"
 				return
 			}
-
-			if strings.Contains(cmdLineArg, "JRockit") {
+			match, _ = regexp.MatchString(".*JRockit.*", cmdLineArg)
+			if match {
 				log.Debug("Detected JRockit JVM")
 				vendor = "JRockit"
 				return
 			}
 		}
 		if strings.Contains(cmdLineArg, "java.vm.vendor") {
-			//cmlineArg would look something like this: -Djava.vm.vendor=Oracle Corporation
-
-			if strings.Contains(cmdLineArg, "Apple") {
+			match, _ := regexp.MatchString("Apple.*", cmdLineArg)
+			if match {
 				log.Debug("Detected Apple JVM")
 				vendor = "Apple"
 				return
 			}
-			if strings.Contains(cmdLineArg, "IBM") {
+			match, _ = regexp.MatchString(".*IBM.*", cmdLineArg)
+			if match {
 				log.Debug("Detected IBM JVM")
 				vendor = "IBM"
 			}
-			if (strings.Contains(cmdLineArg, "Oracle")) && vendor != "HotSpot" {
+			match, _ = regexp.MatchString("Oracle.*", cmdLineArg)
+			if match == true && vendor != "HotSpot" {
 				log.Debug("Detected Oracle JVM")
 				vendor = "Oracle"
 			}
@@ -544,7 +514,7 @@ func (p JavaJVMVendorsVersions) isFullySupported(vendor string, version string) 
 		return false
 	}
 
-	requirements := supportedVersions[vendor]
+	requirements := compatibilityVars.SupportedJavaVersions[vendor]
 
 	if requirements != nil {
 		return isItCompatible(version, requirements)
@@ -566,7 +536,7 @@ func (p JavaJVMVendorsVersions) isLegacySupported(vendor string, version string)
 		return false
 	}
 
-	requirements := supportedForJavaAgent4[vendor]
+	requirements := compatibilityVars.SupportedForJavaAgent4[vendor]
 
 	if requirements != nil {
 		return isItCompatible(version, requirements)

--- a/tasks/java/jvm/vendorsVersions_test.go
+++ b/tasks/java/jvm/vendorsVersions_test.go
@@ -5,10 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/shirou/gopsutil/process"
-	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
 func TestJavaJVMVendorsVersion(t *testing.T) {

--- a/tasks/node/env/env.go
+++ b/tasks/node/env/env.go
@@ -22,10 +22,6 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		cmdExec: tasks.CmdExecutor,
 	}, true)
 
-	registrationFunc(NodeEnvVersionCompatibility{
-		supportedNodeVersions: []string{"6.0+"},
-	}, true)
-
 	registrationFunc(NodeEnvNpmPackage{
 		Getwd:      os.Getwd,
 		fileFinder: tasks.FindFiles,

--- a/tasks/node/env/versionCompatibility.go
+++ b/tasks/node/env/versionCompatibility.go
@@ -2,16 +2,15 @@ package env
 
 import (
 	"fmt"
+	"strconv"
+	"strings"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks/compatibilityVars"
 )
-
-// To update compatibility requirements, modify what's the contents of supportedNodeVersions
-// which are passed to this task's registrationFunc in this package's defintiion file (./env.go)
 
 // NodeEnvVersionCompatibility - This struct defines Node.js version compatibility
 type NodeEnvVersionCompatibility struct {
-	supportedNodeVersions []string
 }
 
 // Identifier - This returns the Category, Subcategory and Name of each task
@@ -26,7 +25,10 @@ func (p NodeEnvVersionCompatibility) Explain() string {
 
 // Dependencies - Returns the dependencies for each task.
 func (p NodeEnvVersionCompatibility) Dependencies() []string {
-	return []string{"Node/Env/Version"}
+	return []string{
+		"Node/Env/Version",
+		"Node/Agent/Version",
+	}
 }
 
 // Execute - The core work within each task
@@ -39,15 +41,42 @@ func (p NodeEnvVersionCompatibility) Execute(options tasks.Options, upstream map
 		}
 	}
 
+	if upstream["Node/Agent/Version"].Status != tasks.Info {
+		return tasks.Result{
+			Summary: "Node Agent Version not detected. This task didn't run.",
+			Status:  tasks.None,
+		}
+	}
+
 	nodeVersion, ok := upstream["Node/Env/Version"].Payload.(tasks.Ver)
-	if !ok {
+	agentVersion, valid := upstream["Node/Agent/Version"].Payload.(string)
+	if !ok || !valid {
 		return tasks.Result{
 			Summary: "Task did not meet requirements necessary to run: type assertion failure",
 			Status:  tasks.None,
 		}
 	}
+	sanitizedNodeVersion := sanitizeNodeVersion(nodeVersion.String())
 
-	isItCompatible, err := nodeVersion.CheckCompatibility(p.supportedNodeVersions)
+	requiredAgentVersions, isNodeVersionSupported := compatibilityVars.NodeSupportedVersions[sanitizedNodeVersion]
+
+	if !isNodeVersionSupported {
+		if isOddVersion(sanitizedNodeVersion) {
+			return tasks.Result{
+				Status:  tasks.Warning,
+				Summary: fmt.Sprintf("Your %s Node Version is not officially supported by the Node Agent because odd versions are considered unstable/experimental releases", sanitizedNodeVersion),
+			}
+		}
+		return tasks.Result{
+			Status:  tasks.Failure,
+			Summary: fmt.Sprintf("Your %s Node version is not in the list of supported versions by the Node Agent. Please review our documentation on version requirements", nodeVersion),
+			URL:     "https://docs.newrelic.com/docs/agents/python-agent/getting-started/compatibility-requirements-python-agent#basic",
+		}
+	}
+
+	//we are dealing with a supported node version, but is it compatible with the agent version they are using?
+	isAgentVersionCompatible, err := tasks.VersionIsCompatible(agentVersion, requiredAgentVersions)
+
 	if err != nil {
 		return tasks.Result{
 			Summary: "There was an issue when checking for Node.js Version compatibility: " + err.Error(),
@@ -55,7 +84,7 @@ func (p NodeEnvVersionCompatibility) Execute(options tasks.Options, upstream map
 		}
 	}
 
-	if !isItCompatible {
+	if !isAgentVersionCompatible {
 		return tasks.Result{
 			Summary: fmt.Sprintf("Your current Node.js version, %v, is not compatible with New Relic's Node.js agent", nodeVersion),
 			Status:  tasks.Failure,
@@ -68,4 +97,17 @@ func (p NodeEnvVersionCompatibility) Execute(options tasks.Options, upstream map
 		Status:  tasks.Success,
 	}
 
+}
+
+func sanitizeNodeVersion(nodeVersion string) string {
+	versionDigits := strings.Split(nodeVersion, ".")
+	return versionDigits[0]
+}
+
+func isOddVersion(nodeVersion string) bool {
+	i, _ := strconv.Atoi(nodeVersion)
+	if i%2 == 0 {
+		return false
+	}
+	return true
 }

--- a/tasks/node/env/versionCompatibility.go
+++ b/tasks/node/env/versionCompatibility.go
@@ -106,8 +106,5 @@ func sanitizeNodeVersion(nodeVersion string) string {
 
 func isOddVersion(nodeVersion string) bool {
 	i, _ := strconv.Atoi(nodeVersion)
-	if i%2 == 0 {
-		return false
-	}
-	return true
+	return i%2 != 0
 }

--- a/tasks/node/env/versionCompatibility_test.go
+++ b/tasks/node/env/versionCompatibility_test.go
@@ -79,7 +79,12 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{10, 0, 0, 0},
+						Payload: tasks.Ver{
+							Major: 10, 
+							Minor: 0, 
+							Patch: 0, 
+							Build: 0,
+						},
 					},
 					"Node/Agent/Version": tasks.Result{
 						Status: tasks.None,
@@ -127,11 +132,21 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{10, 6, 7, 456},
+						Payload: tasks.Ver{
+							Major: 10, 
+							Minor: 6, 
+							Patch: 7, 
+							Build: 456,
+						},
 					},
 					"Node/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{6, 0, 0, 0},
+						Payload: tasks.Ver{
+							Major: 6, 
+							Minor: 0, 
+							Patch: 0, 
+							Build: 0,
+						},
 					},
 				}
 			})
@@ -151,7 +166,12 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{11, 0, 0, 0},
+						Payload: tasks.Ver{
+							Major: 11, 
+							Minor: 0, 
+							Patch: 0, 
+							Build: 0,
+						},
 					},
 					"Node/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
@@ -176,7 +196,12 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{8, 0, 0, 0},
+						Payload: tasks.Ver{
+							Major: 8, 
+							Minor: 0, 
+							Patch: 0, 
+							Build: 0,
+						},
 					},
 					"Node/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
@@ -201,7 +226,12 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{10, 0, 0, 0},
+						Payload: tasks.Ver{
+							Major: 10, 
+							Minor: 0, 
+							Patch: 0, 
+							Build: 0,
+						},
 					},
 					"Node/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
@@ -226,7 +256,12 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{12, 0, 0, 0},
+						Payload: tasks.Ver{
+							Major: 12, 
+							Minor: 0, 
+							Patch: 0, 
+							Build: 0,
+						},
 					},
 					"Node/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
@@ -251,7 +286,12 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: tasks.Ver{12, 0, 0, 0},
+						Payload: tasks.Ver{
+							Major: 12, 
+							Minor: 0, 
+							Patch: 0, 
+							Build: 0,
+						},
 					},
 					"Node/Agent/Version": tasks.Result{
 						Status:  tasks.Info,

--- a/tasks/node/env/versionCompatibility_test.go
+++ b/tasks/node/env/versionCompatibility_test.go
@@ -1,9 +1,9 @@
 package env
 
 import (
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
 var _ = Describe("Node/Env/VersionCompatibility", func() {
@@ -31,7 +31,7 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 
 	Describe("Dependencies()", func() {
 		It("Should return correct slice", func() {
-			expectedDependencies := []string{"Node/Env/Version"}
+			expectedDependencies := []string{"Node/Env/Version", "Node/Agent/Version"}
 
 			Expect(p.Dependencies()).To(Equal(expectedDependencies))
 		})
@@ -48,42 +48,18 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 			result = p.Execute(options, upstream)
 		})
 
-		Context("when Node.js version does not return an string", func() {
+		Context("when Node.js version does not return anything", func() {
 
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
+						Status: tasks.None,
+					},
+					"Node/Agent/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: 4,
+						Payload: "6.0.0.0",
 					},
-				}
-				p = NodeEnvVersionCompatibility{
-					supportedNodeVersions: []string{"6.0+"},
-				}
-			})
-
-			It("should return an expected none result status", func() {
-				Expect(result.Status).To(Equal(tasks.None))
-			})
-
-			It("should return an expected none result summary", func() {
-				Expect(result.Summary).To(Equal("Task did not meet requirements necessary to run: type assertion failure"))
-			})
-		})
-
-		Context("when upstream dependency does not return successful status", func() {
-
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Error,
-						Payload: "4",
-					},
-				}
-				p = NodeEnvVersionCompatibility{
-					supportedNodeVersions: []string{"6.0+"},
 				}
 			})
 
@@ -96,76 +72,196 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 			})
 		})
 
-		Context("when running Ver.IsCompatible returns an error", func() {
+		Context("when Node.js Agent version does not return anything", func() {
 
 			BeforeEach(func() {
 				options = tasks.Options{}
-				parsedVer, _ := tasks.ParseVersion("6.0.1.2")
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: parsedVer,
+						Payload: tasks.Ver{10, 0, 0, 0},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status: tasks.None,
 					},
 				}
-				p = NodeEnvVersionCompatibility{
-					supportedNodeVersions: []string{"I Am Not AVersionRequirement"},
-				}
-
 			})
 
-			It("should return an expected error result status", func() {
+			It("should return an expected none result status", func() {
+				Expect(result.Status).To(Equal(tasks.None))
+			})
+
+			It("should return an expected none result summary", func() {
+				Expect(result.Summary).To(Equal("Node Agent Version not detected. This task didn't run."))
+			})
+		})
+
+		Context("When Node Version returns a wrong type", func() {
+
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Node/Env/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "10.6.7.456",
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "6.0.0.0",
+					},
+				}
+			})
+			It("should return an expected none result status", func() {
+				Expect(result.Status).To(Equal(tasks.None))
+			})
+
+			It("should return an expected None for not meeting requirements", func() {
+				Expect(result.Summary).To(Equal("Task did not meet requirements necessary to run: type assertion failure"))
+			})
+		})
+
+		Context("When Node Agent Version returns a wrong type", func() {
+
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Node/Env/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: tasks.Ver{10, 6, 7, 456},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: tasks.Ver{6, 0, 0, 0},
+					},
+				}
+			})
+			It("should return an expected none result status", func() {
+				Expect(result.Status).To(Equal(tasks.None))
+			})
+
+			It("should return an expected None for not meeting requirements", func() {
+				Expect(result.Summary).To(Equal("Task did not meet requirements necessary to run: type assertion failure"))
+			})
+		})
+
+		Context("When an odd version of Node.js is used", func() {
+
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Node/Env/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: tasks.Ver{11, 0, 0, 0},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "6.0.0.0",
+					},
+				}
+			})
+
+			It("should return an expected Warning result status", func() {
+				Expect(result.Status).To(Equal(tasks.Warning))
+			})
+
+			It("should return an expected Warning for an odd version", func() {
+				Expect(result.Summary).To(Equal("Your 11 Node Version is not officially supported by the Node Agent because odd versions are considered unstable/experimental releases"))
+			})
+		})
+
+		Context("When an invalid version of Node.js is used", func() {
+
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Node/Env/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: tasks.Ver{8, 0, 0, 0},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "6.0.0.0",
+					},
+				}
+			})
+
+			It("should return an expected Failure result status", func() {
+				Expect(result.Status).To(Equal(tasks.Failure))
+			})
+
+			It("should return an expected Warning for an odd version", func() {
+				Expect(result.Summary).To(Equal("Your 8.0.0.0 Node version is not in the list of supported versions by the Node Agent. Please review our documentation on version requirements"))
+			})
+		})
+
+		Context("When VersionIsCompatible returns an error", func() {
+
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Node/Env/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: tasks.Ver{10, 0, 0, 0},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "potato",
+					},
+				}
+			})
+
+			It("should return an expected Error result status", func() {
 				Expect(result.Status).To(Equal(tasks.Error))
 			})
 
-			It("should return an expected error result summary", func() {
-				Expect(result.Summary).To(Equal("There was an issue when checking for Node.js Version compatibility: Unable to parse version: I Am Not AVersionRequirement"))
+			It("should return an expected Error for the string being passed in", func() {
+				Expect(result.Summary).To(Equal("There was an issue when checking for Node.js Version compatibility: Unable to parse version: potato"))
 			})
 		})
 
-		Context("When running versionIsCompatible returns false", func() {
+		Context("When VersionIsCompatible returns false", func() {
 
 			BeforeEach(func() {
 				options = tasks.Options{}
-				parsedVer, _ := tasks.ParseVersion("5.0.7")
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: parsedVer,
+						Payload: tasks.Ver{12, 0, 0, 0},
 					},
-				}
-				p = NodeEnvVersionCompatibility{
-					supportedNodeVersions: []string{"6.0+"},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "4.6.0.0",
+					},
 				}
 			})
 
-			It("should return an expected failure result status", func() {
+			It("should return an expected Failure result status", func() {
 				Expect(result.Status).To(Equal(tasks.Failure))
 			})
-			It("should return an expected failure result summary", func() {
-				Expect(result.Summary).To(Equal("Your current Node.js version, 5.0.7.0, is not compatible with New Relic's Node.js agent"))
+
+			It("should return an expected Failure for the incompatible versions", func() {
+				Expect(result.Summary).To(Equal("Your current Node.js version, 12.0.0.0, is not compatible with New Relic's Node.js agent"))
 			})
 		})
-		Context("When running versionIsCompatible returns true", func() {
+
+		Context("When an even valid version of Node.js is used", func() {
 
 			BeforeEach(func() {
 				options = tasks.Options{}
-				parsedVer, _ := tasks.ParseVersion("10.0.7")
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
 						Status:  tasks.Info,
-						Payload: parsedVer,
+						Payload: tasks.Ver{12, 0, 0, 0},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "6.0.0.0",
 					},
 				}
 			})
-			p = NodeEnvVersionCompatibility{
-				supportedNodeVersions: []string{"6.0+"},
-			}
 
-			It("should return an expected success result status", func() {
-				Expect(result.Status).To(Equal(tasks.Success))
-			})
-			It("should return an expected succes result summary", func() {
-				Expect(result.Summary).To(Equal("Your current Node.js version, 10.0.7.0, is compatible with New Relic's Node.js agent"))
+			It("should return an expected Warning for an odd version", func() {
+				Expect(result.Summary).To(Equal("Your current Node.js version, 12.0.0.0, is compatible with New Relic's Node.js agent"))
 			})
 		})
 	})

--- a/tasks/python/requirements/pythonVersion.go
+++ b/tasks/python/requirements/pythonVersion.go
@@ -6,20 +6,10 @@ import (
 	"strings"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks/compatibilityVars"
 )
 
 //https://github.com/edmorley/newrelic-python-agent/blame/master/newrelic/setup.py#L100
-var pythonVersionAgentSupportability = map[string][]string{
-	//the keys are the python version and the values are the agent versions that support that specific version
-	"3.8": []string{"5.2.3.131+"},
-	"3.7": []string{"3.4.0.95+"},
-	"3.6": []string{"2.80.0.60+"},
-	"3.5": []string{"2.78.0.57+"},
-	"3.4": []string{"2.42.0.35-4.20.0.120"},
-	"3.3": []string{"2.42.0.35-3.4.0.95"},
-	"2.7": []string{"2.42.0.35+"},
-	"2.6": []string{"2.42.0.35-3.4.0.95"},
-}
 
 // PythonRequirementsPythonVersion  - This struct defines the Python Version requirement
 type PythonRequirementsPythonVersion struct {
@@ -65,7 +55,7 @@ func (t PythonRequirementsPythonVersion) Execute(options tasks.Options, upstream
 
 	sanitizedPyVersion := removePyVersionPatch(pyVersion)
 
-	requiredAgentVersions, isPythonVersionSupported := pythonVersionAgentSupportability[sanitizedPyVersion]
+	requiredAgentVersions, isPythonVersionSupported := compatibilityVars.PythonVersionAgentSupportability[sanitizedPyVersion]
 
 	if !isPythonVersionSupported {
 		return tasks.Result{

--- a/tasks/python/requirements/pythonVersion_test.go
+++ b/tasks/python/requirements/pythonVersion_test.go
@@ -3,9 +3,9 @@ package requirements
 import (
 	"fmt"
 
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
 var _ = Describe("Python/Requirements/PythonVersion", func() {

--- a/tasks/ruby/requirements/version.go
+++ b/tasks/ruby/requirements/version.go
@@ -4,28 +4,15 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 	"strconv"
+	"strings"
 
 	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks/compatibilityVars"
 )
 
 //https://github.com/edmorley/newrelic-python-agent/blame/master/newrelic/setup.py#L100
-var rubyVersionAgentSupportability = map[string][]string{
-	//the keys are the ruby version and the values are the agent versions that support that specific version
-	"2.7":   []string{"6.9.0.363+"},
-	"2.6":   []string{"5.7.0.350+"},
-	"2.5":   []string{"4.8.0.341+"},
-	"2.4":   []string{"3.18.0.329+"},
-	"2.3":   []string{"3.9.9.275+"},
-	"2.2":   []string{"3.9.9.275+"},
-	"2.1":   []string{"3.9.9.275+"},
-	"2.0":   []string{"3.9.6.257+"},
-	"1.9.3": []string{"3.9.6.257-3.18.1.330"},
-	"1.9.2": []string{"3.9.6.257-3.18.1.330"},
-	"1.8.7": []string{"3.9.6.257-3.18.1.330"},
-}
 
 // RubyRequirementsVersion  - This struct defines the Ruby Version requirement
 type RubyRequirementsVersion struct {
@@ -78,7 +65,7 @@ func (t RubyRequirementsVersion) Execute(options tasks.Options, upstream map[str
 		}
 	}
 
-	requiredAgentVersions, isRubyVersionSupported := rubyVersionAgentSupportability[sanitizedRubyVersion]
+	requiredAgentVersions, isRubyVersionSupported := compatibilityVars.RubyVersionAgentSupportability[sanitizedRubyVersion]
 
 	if !isRubyVersionSupported {
 		return tasks.Result{

--- a/tasks/ruby/requirements/version_test.go
+++ b/tasks/ruby/requirements/version_test.go
@@ -3,9 +3,9 @@ package requirements
 import (
 	"testing"
 
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
 func TestRequirements(t *testing.T) {

--- a/tasks/taskHelpers.go
+++ b/tasks/taskHelpers.go
@@ -591,7 +591,6 @@ var defaultEnvVarFilter = []string{
 	"^APP_ENV$",
 	"^RACK_ENV$",
 	"^LOCALAPPDATA$",
-	"^DOTNET_SDK_VERSION$",
 	"^DOTNET_INSTALL_PATH$",
 	"^COR_PROFILER$",
 	"^COR_PROFILER_PATH$",


### PR DESCRIPTION
…ed paths from source.datanerd.us... to github.com.diagnostics_cli... and made sure unit tests worked.  This is still in progress

# Issue
Tasks from old NR Diag had not yet been moved to the Diagnostics CLI.  On top of this, the old tasks had the old source.datanerd path and that needed to be changed.  The overarching goal for the overhauling change to compatibilityVars was to keep our version compatibility for each different tasks (node, ruby, python, java, etc.) in one location and to have it have one standard format for input.  Before, our variable compatibility was very different as some were stored as strings and some were stored as maps.  Along with that, some variable checks were hard-coded in while others were stored in local variables.

# Goals
The goal of this tasks was to have a more up to date and standard way of checking version compatibility for each tasks.  We no longer want hard coded variables, but rather a central location where version compatibility will be easier to update.

# Implementation Details
I added a compatibilityVars package that is included in each task.  There is also a unit test to make sure that each file works properly with compatiblityVars

# How to Test
In order to test, go into each file (filename_test.go) and run the package tests.