### PR TITLE
add comment on running Diagnostics CLI with `sudo -E`

### DIFF
--- a/output/outputHelpers.go
+++ b/output/outputHelpers.go
@@ -17,7 +17,7 @@ import (
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
 
-const permissionsError = "\n------Error creating output files.------\n Please check to ensure you have rights to creating files in the local directory or specify a different output directory with -output-path\n"
+const permissionsError = "\n------Error creating output files.------\nEnsure you have rights for creating files in the local directory or specify a different output directory with -output-path\nA 'permission denied' error may be solved by re-running this program prefixed by the command 'sudo -E'. The '-E' option will help preserve the environment variables needed for running this program."
 
 type resultsOutput struct {
 	RunDate       time.Time
@@ -85,7 +85,7 @@ func CloseZip(zipfile *zip.Writer) {
 	log.Debug("Done executing tasks, closing zip file")
 	zipErr := zipfile.Close()
 	if zipErr != nil {
-		log.Info("error closing zip file", zipErr)
+		log.Info("error closing zip file: ", zipErr)
 	}
 }
 
@@ -144,13 +144,13 @@ func copyFilesToZip(dst *zip.Writer, filesToZip []tasks.FileCopyEnvelope) {
 			writer, err := dst.CreateHeader(header)
 
 			if err != nil {
-				log.Info("Error writing results to zip file", err)
+				log.Info("Error writing results to zip file: ", err)
 				return
 			}
 
 			_, err = io.Copy(writer, fileHandle)
 			if err != nil {
-				log.Info("Error writing file into zip", err)
+				log.Info("Error writing file into zip: ", err)
 			}
 		}
 

--- a/tasks/infra/env/validateZookeeperPath_linux.go
+++ b/tasks/infra/env/validateZookeeperPath_linux.go
@@ -98,7 +98,7 @@ func (p InfraEnvValidateZookeeperPath) Execute(options tasks.Options, upstream m
 	if zookeeperShellPath == "" {
 		return tasks.Result{
 			Status:  tasks.Error,
-			Summary: `This health check cannot be completed because it requires running the zookeeper-shell script and we were unable to locate your Kafka directory through the current $PATH. If you are sure to have it, and happen to be running "sudo" alongside our Diagnostics CLI tool, keep in mind that "sudo" will reset your path. You can avoid this with: sudo env "PATH=$PATH"`,
+			Summary: `This health check cannot be completed because it requires running the zookeeper-shell script and we were unable to locate your Kafka directory through the current $PATH. If you are sure to have it, and happen to be running "sudo" alongside our Diagnostics CLI tool, keep in mind that "sudo" will reset your path. You can avoid this with: sudo -E`,
 		}
 	}
 	/*how we pass the args to the zk shell may differ depending on the version of the shell:


### PR DESCRIPTION
# Issue
Diagnostics CLI can fail to captured the nrdiag-output.json and nrdiag-output.zip when the Linux user is not running as the root user and has run `./nrdiag` instead of `sudo ./nrdiag`

the error will look like this:

```
Error writing output file open .//nrdiag-filelist.txt: permission denied

------Error creating output files.------
 Please check to ensure you have rights to creating files in the local directory or specify a different output directory with -output-path

Error writing output file invalid argument
Error writing output file open .//nrdiag-filelist.txt: permission denied

------Error creating output files.------
 Please check to ensure you have rights to creating files in the local directory or specify a different output directory with -output-path

Error writing output file invalid argument
Error writing file into zip invalid argument
Error writing output file open .//nrdiag-filelist.txt: permission denied

------Error creating output files.------
 Please check to ensure you have rights to creating files in the local directory or specify a different output directory with -output-path

Error writing output file invalid argument
Error writing results to zip file invalid argument
Error writing results to zip file invalid argument
Error writing results to zip file invalid argument
error closing zip file invalid argument
```

Though these errors do make it clear that is related to the user not having enough permissions to capture the output, it would be helpful to add a recommendation to tell the user that they should run the command with `sudo -E`. Why `sudo -E` instead of just `sudo`? When you run `sudo`, you are actually starting a new environment as the root user, so any environment variables that exist in your current shell will not be passed.  Some nrdiag tasks depend on reading the user's env vars, and if we cannot access them, then those tasks will not run properly. The `sudo` command has a handy argument `-E` or `--preserve-env` which will pass all your environment variables into the `sudo` environment.

# Goals
1. Recommend the user to run `sudo` when we are unable to capture the nrdiag output due to permission denied.
2. Additionally, recommend the user to add the `-E` option to allow nrdiag to access env vars needed for some tasks.

# Implementation Details

# How to Test