### PR TITLE
bubble up error when we are unable to get dotnet core version

### DIFF
--- a/tasks/dotnetcore/env/versions.go
+++ b/tasks/dotnetcore/env/versions.go
@@ -1,13 +1,13 @@
 package env
 
 import (
+	"fmt"
 	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/logger"
@@ -37,7 +37,6 @@ func (t DotNetCoreEnvVersions) Dependencies() []string {
 
 // Execute - The core work within each task
 func (t DotNetCoreEnvVersions) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
-	var result tasks.Result
 
 	// Gather env variables from upstream
 	envVars, ok := upstream["Base/Env/CollectEnvVars"].Payload.(map[string]string) //This is a type assertion to cast my upstream results back into data I know the structure of and can now work with. In this case, I'm casting it back to the map[string]string I know it should return
@@ -47,55 +46,41 @@ func (t DotNetCoreEnvVersions) Execute(options tasks.Options, upstream map[strin
 		logger.Debug("DotNetCoreVersions - Successfully gathered Environment Variables from upstream.")
 	}
 
-	versions, checkVersionErrorCount, checkVersionsErrorDetails := checkVersions(envVars)
+	versions, errorMessage := checkVersions(envVars)
 
-	if versions == nil || len(versions) < 1 {
-		if checkVersionsErrorDetails != nil || checkVersionErrorCount > 0 {
-			result.Status = tasks.Error
-			result.Summary = "Error determining the version .NET Core installed."
-			return result
+	if len(versions) < 1 {
+		return tasks.Result{
+			Status: tasks.Error,
+			Summary: errorMessage,
 		}
-
-		logger.Debug("DotNetCoreVersions - No .NET Core version information found.")
-		result.Status = tasks.None
-		result.Summary = ".NET Core is not installed."
-		return result
 	}
-
-	if checkVersionErrorCount > 0 {
-		logger.Debug("DotNetCoreVersions - There were", checkVersionErrorCount, "errors, but also found", strconv.Itoa(len(versions)), ".NET Core versions installed. Marking successful, not reporting errors.")
+	return tasks.Result{
+		Status: tasks.Info,
+		Summary: strings.Join(versions, ", "),
+		Payload: versions,
 	}
-
-	if checkVersionsErrorDetails != nil {
-		logger.Debug("DotNetCoreVersions - There was an error, but also found", strconv.Itoa(len(versions)), ".NET Core versions installed. Marking successful, not reporting errors.")
-		logger.Debug("DotNetCoreVersions - Error was:", checkVersionsErrorDetails.Error())
-	}
-
-	result.Summary = strings.Join(versions, ", ")
-	result.Status = tasks.Info
-	result.Payload = versions
-	return result
 }
 
-func checkVersions(envVars map[string]string) (versions []string, countErrors int, retErr error) {
-	countErrors = 0
-
+func checkVersions(envVars map[string]string) ([]string, string) {
+	errorMessage := "Unable to complete this health check because we ran into some unexpected errors when attempting to collect this application's .NET Core SDK version:\n"
+	versions := []string{}
 	// first check if version is accesible through the cmdline
 	//dotnet --version will Display .NET Core SDK version. Ex: 5.0.101
 	version, err := tasks.CmdExecutor("dotnet", "--version")
 
 	if err != nil {
-		countErrors++
-		logger.Debug("unable to get the version with the cmd dotnet --version:", err)
+		errorMessage += fmt.Sprint("Unable to run 'dotnet --version':\n%w\n", err)
 	} else {
-		return []string{string(version)}, countErrors, nil
+		versions = append(versions, string(version))
+		return versions, errorMessage
 	}
 
 	// check dirs
-	dirsToRead, retErr := buildDirsToRead(envVars)
-	if retErr != nil {
-		countErrors++
-		return []string{}, countErrors, retErr
+	dirsToRead, errRead := buildDirsToRead(envVars)
+
+	if errRead != nil {
+		errorMessage += fmt.Sprint("Unable to find version in dotnet sdk path:\n%w\n", errRead)
+		return []string{}, errorMessage
 	}
 
 	logger.Debug("DotNetCoreVersions - dirs to read:", dirsToRead)
@@ -109,8 +94,7 @@ func checkVersions(envVars map[string]string) (versions []string, countErrors in
 				continue // don't care about this error
 			}
 			logger.Debug("DotNetCoreVersions - Error reading '", directory, "'. Error: ", err.Error())
-			retErr = err  // keep track of the last error
-			countErrors++ // keep track of how many errors we encounter
+			errorMessage += fmt.Sprint("Unable to read from dotnet sdk path:\n%w\n", err)
 			continue      // go to the next directory
 		}
 
@@ -124,7 +108,7 @@ func checkVersions(envVars map[string]string) (versions []string, countErrors in
 		}
 	}
 
-	return versions, countErrors, retErr
+	return versions, errorMessage
 }
 
 func buildDirsToRead(envVars map[string]string) (dirsToRead []string, retErr error) {


### PR DESCRIPTION
# Issue
1. The task DotnetCoreEnvVersions is not showing the errors when it is unable to find the .NET core SDK version. The error summary only says: "Error determining the version .NET Core installed" when we actually do have access to the error itself. So we just need to add it to the summary.
2. The payload of DotnetCoreEnvVersions (a slice of strings. Each string is supposed to be a version) is used as an upstream payload in the task DotNetCore/Requirements/DotNetCoreVersion. When iterating through that upstream payload, we were attempting to get major, minor digits for each item (`coreVersion`): `majorVer, minorVer, _, _ := tasks.GetVersionSplit(coreVersion)` . But what if the item we are iterating through is not a string that has well-defined digits we can parse through? Ex: `.NET Core 5.0.101` instead of just `5.0.101`

# Goals
1. Add errors output to the result summary message if we were unable to get a NET core SDK version in DotnetCoreEnvVersions task
2. Take into account that the payload received from DotnetCoreEnvVersions could contain a string that is not a parseable version.

# Implementation Details

# How to Test