### PR TITLE
Add rollout workflow

### DIFF
--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -25,15 +25,8 @@ jobs:
         shell: bash
         run: |
             echo "deleting tag associated with latest release:"
-            echo ${{ steps.flr.outputs }}
-            echo ${{ steps.flr.outputs.tag_name }}
-            git push --delete origin v.lasttest
-#"ref": "refs/tags/v.test"
-#             git push --delete origin ${{ steps.flr.outputs.tag_name }}
-      - name: Debug GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
+            git push --delete origin ${{ steps.flr.outputs.tag_name }}
+#Alternatively we could use the Github Context ref("ref": "refs/tags/v.test") to delete the current tag_name we just deleted manually
       - name: remove nrdiag zip files from download.newrelic.com related to last release
         shell: bash
         env:

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -7,21 +7,20 @@ CURRENTZIP="nrdiag_${CURRENT}.zip"
 PREV=$(cat releaseVersion.txt | awk -F'prevReleaseVersion=' '{printf$2}')
 PREVZIP="nrdiag_${PREV}.zip"
 
-echo "aws version is:"
+echo "current aws version is:"
 aws --version
 
 echo "deleting current release zip file ..."
-aws s3 rm s3://${S3_BUCKET}/nrdiag/test/${CURRENTZIP}
+aws s3 rm s3://${S3_BUCKET}/nrdiag/${CURRENTZIP}
 
 echo "deleting version.txt ..."
-aws s3 rm s3://${S3_BUCKET}/nrdiag/test/version.txt
+aws s3 rm s3://${S3_BUCKET}/nrdiag/version.txt
 echo "creating a new version.txt inserting the previous version ..."
 echo ${PREV} >> version.txt
-aws s3 cp version.txt s3://${S3_BUCKET}/nrdiag/test/version.txt
+aws s3 cp version.txt s3://${S3_BUCKET}/nrdiag/version.txt
 echo "version is now:"
-aws s3 cp s3://nr-downloads-main/nrdiag/test/version.txt -
+aws s3 cp s3://nr-downloads-main/nrdiag/version.txt -
 
 echo "replacing nrdiag_latest.zip to be the previous one ..."
-#--copy-props metadata-directive parameter is to avoid calling GetObjectTagging permission
-#Unknown options: --copy-props,s3://***/nrdiag/test/nrdiag_latest.zip
-aws s3 cp s3://${S3_BUCKET}/nrdiag/test/${PREVZIP} s3://${S3_BUCKET}/nrdiag/test/nrdiag_latest.zip
+#once ubuntu-latest image upgrades their aws version to version 2, we'll need to update this command to use "--copy-props metadata-directive" arguments to avoid calling GetObjectTagging permission when copying a  file from bucket to bucket:
+aws s3 cp s3://${S3_BUCKET}/nrdiag/${PREVZIP} s3://${S3_BUCKET}/nrdiag/nrdiag_latest.zip


### PR DESCRIPTION
# Issue
The original PR to add a rollback workflow: https://github.com/newrelic/newrelic-diagnostics-cli/pull/52
exposed that this workflow needed some adjustments after we merged it, tested it, and found some errors. But, as mentioned in that previous PR, that was the whole purpose of merging that PR: To expose any possible production errors that were not shown when this rollback process was tested locally.

Some of the errors that we uncovered:

1) The workflow couldn't use the GH action library `thebritican/fetch-latest-release@v1` because I needed to specify a concrete real version such as `thebritican/fetch-latest-release@v2.0.0`

2) The command `aws s3 cp s3://${S3_BUCKET}/nrdiag/${PREVZIP} s3://${S3_BUCKET}/nrdiag/test/nrdiag_latest.zip --copy-props metadata-directive` was failing with the error `unknown options:--copy-props,metadata-directive`. 
When testing locally, I was using AWS CLI V.2. Using the command `aws s3 cp s3://${S3_BUCKET}/nrdiag/${PREVZIP} s3://${S3_BUCKET}/nrdiag/test/nrdiag_latest.zip` (without `-copy-props,metadata-directive`) would throw permission denied error because when copying a file from one bucket to another bucket, it would attempt to copy the tags, and this requires a `GetObjectTagging` permission, and it looks like our bucket does not have that permission.
The AWS documentation on breaking changes between CLI version 1 and version 2 said(https://docs.aws.amazon.com/cli/latest/userguide/cliv2-migration.html): "If you need to change this default behavior in AWS CLI version 2 commands, use the --copy-props parameter". So I applied that parameter.
But after seeing that my GH action was failing with `unknown options:--copy-props,metadata-directive`, I log the AWS version and noticed that this `ubuntu-latest` image used by my workflow is running AWS CLI V1.18.219.

# Goals
1) Fix these issues and some other minor ones that I ran into while smoke testing.
2) Point to the official release bucket `3://${S3_BUCKET}/nrdiag/` and no longer the test bucker `3://${S3_BUCKET}/nrdiag/test/` now that we know that this workflow is fully working.
Proof of that can be seen in the latest workflow that I ran: https://github.com/newrelic/newrelic-diagnostics-cli/runs/1786813734?check_suite_focus=true
No errors, yay!
@pmillspdx 
# Implementation Details

# How to Test
No need for additional smoke testing as I am [showing here]( https://github.com/newrelic/newrelic-diagnostics-cli/runs/1786813734?check_suite_focus=true) that the latest workflow ran properly after making the necessary adjustments. At this point, all we need with this PR is to clean the workflow a little and point to the official bucket rather than the testing one. 