### PR TITLE
update validateLicenseKey to not give a failure status and summary to…

### DIFF
--- a/tasks/base/config/validateLicenseKey.go
+++ b/tasks/base/config/validateLicenseKey.go
@@ -98,11 +98,13 @@ func (p BaseConfigValidateLicenseKey) Execute(options tasks.Options, upstream ma
 			}
 			resultsPayload = validFormatLKToSources
 		}
+
 		if len(invalidAccountLKToSources) > 0 {
 			for lk, sources := range invalidAccountLKToSources {
-				failureSummary += fmt.Sprintf("The license key found in %s did not pass our validation check when verifying against your account:\n%s\nIf your agent is reporting an 'Invalid license key' log entry, please reach out to New Relic Support.\n\n", strings.Join(sources, ",\n "), lk)
+				warningSummary += fmt.Sprintf("The license key found in %s did not match the one assigned to your account:\n%s\nIf you are using an 'ingest key', ignore this warning. Ingest keys are secondary license keys manage by their own users that we do not validate for. Read more about ingest keys - https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys\n\n", strings.Join(sources, ",\n "), lk)
 			}
 		}
+
 		if len(validAccountLKToSources) > 0 {
 			for lk, sources := range validAccountLKToSources {
 				successSummary += fmt.Sprintf("The license key found in %s passed our validation check when verifying against your account:\n %s"+"\n", strings.Join(sources, ",\n "), lk)

--- a/tasks/base/config/validateLicenseKey_test.go
+++ b/tasks/base/config/validateLicenseKey_test.go
@@ -146,8 +146,8 @@ var _ = Describe("BaseConfigValidateLicenseKey", func() {
 			})
 
 			It("Should return a None status and summary", func() {
-				Expect(result.Status).To(Equal(tasks.Failure))
-				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in C:\ProgramData\New Relic\.NET Agent\newrelic.config,` + "\n " + `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml` + " did not pass our validation check when verifying against your account:\neu01xx66c637a29c3982469a3fe8d1982d00NRAL\nIf your agent is reporting an 'Invalid license key' log entry, please reach out to New Relic Support.\n\n"))
+				Expect(result.Status).To(Equal(tasks.Warning))
+				Expect(result.Summary).To(Equal(`We validated 1 license key(s):` + "\n" + `The license key found in C:\ProgramData\New Relic\.NET Agent\newrelic.config,` + "\n " + `C:\Program Files\New Relic\newrelic-infra\newrelic-infra.yml` + " did not match the one assigned to your account:\neu01xx66c637a29c3982469a3fe8d1982d00NRAL\nIf you are using an 'ingest key', ignore this warning. Ingest keys are secondary license keys manage by their own users that we do not validate for. Read more about ingest keys - https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys\n\n"))
 
 			})
 		})


### PR DESCRIPTION
… customers using nerdgraph ingest keys

# Issue
nrdiag is giving a false positive for customers using ingest keys(https://docs.newrelic.com/docs/apis/nerdgraph/examples/use-nerdgraph-manage-license-keys-user-keys). This a new type of key that customers will manage themselves and generate through nerdgraph. These types of keys, even though they are considered License Keys, they are not associated with an rpm account. 

When a customer registers an account/email with New Relic they will get assigned an Account License Key and this is the kind of LK that we look for in our validation ValidateLicenseKey.go. Whereas secondary license keys like the Ingest Keys will fail the validation.

Customers can use either the ingest key or the account License key to report data for APM. Both options will work for them so we should not give them a failure status when they use ingest keys. It is best to let them know that if the validation against the account failed, it is possibly because they are using Ingest keys.

# Goals
If the validation fails, then we'll give the user the benefit of the doubt in case they are using an ingest key. Instead of giving them a Failure status and failure summary, we'll give a warning that this validation does not account for ingests keys only account License Key.

# Implementation Details
You may wonder why do still bother attempting to validate an Ingest Key as we would with a regular Account License key: https://github.com/newrelic/newrelic-diagnostics-cli/blob/6ce1511419a1663901142663581ef00958b9801e/tasks/base/config/validateLicenseKey.go#L93
This is because the format of Ingest Keys is exactly the same as Account License Key, so I could not find a way to declare that we are dealing with an Ingest key rather than an Account License Key. So I still rather go through the trouble of validating against the account any License Key that passes our format check.

# How to Test
I have smoke tested this task by getting myself Ingest keys for my personal account. The changes performed as expected. I got this warning when using the ingest key in my config file: https://github.com/newrelic/newrelic-diagnostics-cli/blob/6ce1511419a1663901142663581ef00958b9801e/tasks/base/config/validateLicenseKey.go#L104
And I got a success status when I used my Account License Key instead.