### PR TITLE
update some Node agent tasks

### DIFF
--- a/tasks/node/config/agent.go
+++ b/tasks/node/config/agent.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 
 	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
@@ -19,6 +20,12 @@ var nodeKeys = []string{
 	"license_key",
 }
 
+var nodeConfigEnvVars = []string{
+	"NEW_RELIC_APP_NAME",
+	"NEW_RELIC_LICENSE_KEY",
+	"NEW_RELIC_NO_CONFIG_FILE", //most agents have an order of precedence and don't force/care if you have anything
+}
+
 // Identifier - This returns the Category, Subcategory and Name of each task
 func (p NodeConfigAgent) Identifier() tasks.Identifier {
 	return tasks.IdentifierFromString("Node/Config/Agent") // This should be updated to match the struct name
@@ -32,6 +39,7 @@ func (p NodeConfigAgent) Explain() string {
 // Dependencies - Returns the dependencies for ech task. When executed by name each dependency will be executed as well and the results from that dependency passed in to the downstream task
 func (p NodeConfigAgent) Dependencies() []string {
 	return []string{
+		"Base/Env/CollectEnvVars",
 		"Base/Config/Collect",
 		"Base/Config/Validate", //This identifies this task as dependent on "Base/Config/Validate" and so the results from that task will be passed to this task. See the execute method to see how to interact with the results.
 	}
@@ -40,6 +48,29 @@ func (p NodeConfigAgent) Dependencies() []string {
 // Execute - The core work within each task
 func (p NodeConfigAgent) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result { //By default this task is commented out. To see it run go to the tasks/registerTasks.go file and uncomment the w.Register for this task
 	var result tasks.Result //This is what we will use to pass the output from this task back to the core and report to the UI
+	if upstream["Base/Env/CollectEnvVars"].Status == tasks.Info {
+		envVars, ok := upstream["Base/Env/CollectEnvVars"].Payload.(map[string]string)
+		if !ok {
+			return tasks.Result{
+				Status:  tasks.Error,
+				Summary: tasks.ThisProgramFullName + " was unable to complete this health check because we ran into an unexpected type assertion error.\nPlease notify this issue to us whenever possible through https://discuss.newrelic.com/ by creating a new topic or through https://github.com/newrelic/newrelic-diagnostics-cli/issues\n",
+			}
+		}
+		foundAllNeededEnvVars := true
+		for _, nodeEnvVarKey := range nodeConfigEnvVars {
+			_, isPresent := envVars[nodeEnvVarKey]
+			if !isPresent {
+				foundAllNeededEnvVars = false
+			}
+		}
+		if foundAllNeededEnvVars {
+			return tasks.Result{
+				Status:  tasks.Success,
+				Summary: "Node agent identified as present on system by detecting the following New Relic Env vars: " + strings.Join(nodeConfigEnvVars, ", "),
+				Payload: []config.ValidateElement{},
+			}
+		}
+	}
 
 	validations, ok := upstream["Base/Config/Validate"].Payload.([]config.ValidateElement) //This is a type assertion to cast my upstream results back into data I know the structure of and can now work with. In this case, I'm casting it back to the []validateElements{} I know it should return
 	if ok {
@@ -93,7 +124,6 @@ func checkValidation(validations []config.ValidateElement) ([]config.ValidateEle
 
 	//Check the validated yml for some node attributes that don't exist in Ruby
 
-
 	for _, validation := range validations {
 		if filepath.Ext(validation.Config.FileName) != ".js" {
 			continue
@@ -108,7 +138,6 @@ func checkValidation(validations []config.ValidateElement) ([]config.ValidateEle
 			}
 		}
 	}
-
 
 	//Check for one or more ValidateElements
 	if len(nodeValidate) > 0 {

--- a/tasks/node/config/agent_test.go
+++ b/tasks/node/config/agent_test.go
@@ -3,43 +3,82 @@ package config
 import (
 	"testing"
 
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks/base/config"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
-func Test_checkValidation(t *testing.T) {
-	type args struct {
-		validations []config.ValidateElement
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, got := checkValidation(tt.args.validations); got != tt.want {
-				t.Errorf("checkValidation() = %v, want %v", got, tt.want)
-			}
-		})
-	}
+func TestNodeEnvOsCheck(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node/Agent/* test suite")
 }
 
-func Test_checkConfig(t *testing.T) {
-	type args struct {
-		configs []config.ConfigElement
-	}
-	tests := []struct {
-		name string
-		args args
-		want bool
-	}{
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if _, got := checkConfig(tt.args.configs); got != tt.want {
-				t.Errorf("checkConfig() = %v, want %v", got, tt.want)
-			}
+var _ = Describe("Node/Config/Agent", func() {
+
+	var p NodeConfigAgent
+
+	Describe("Dependencies()", func() {
+		It("Should return an slice required to run this task", func() {
+			expectedDependencies := []string{"Base/Env/CollectEnvVars",
+				"Base/Config/Collect",
+				"Base/Config/Validate"}
+			Expect(p.Dependencies()).To(Equal(expectedDependencies))
 		})
-	}
-}
+	})
+	Describe("Execute()", func() {
+		var (
+			//inputs
+			options  tasks.Options
+			upstream map[string]tasks.Result
+			//output
+			result tasks.Result
+		)
+		JustBeforeEach(func() {
+			result = p.Execute(options, upstream)
+		})
+		Context("When node agent validation is available", func() {
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Base/Env/CollectEnvVars": tasks.Result{
+						Status: tasks.Info,
+						Payload: map[string]string{
+							"NEW_RELIC_APP_NAME": "luces-app",
+						},
+					},
+					"Base/Config/Validate": tasks.Result{
+						Status: tasks.Success,
+						Payload: []config.ValidateElement{
+							{
+								Config: config.ConfigElement{
+									FileName: "newrelic.js",
+									FilePath: "/newrelic/newrelic.js",
+								},
+								ParsedResult: tasks.ValidateBlob{
+									Key:      "",
+									Path:     "",
+									RawValue: nil,
+									Children: []tasks.ValidateBlob{
+										tasks.ValidateBlob{
+											Key:      "app_name",
+											Path:     "",
+											RawValue: "luces-app",
+											Children: nil,
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+			It("Should return a None result status", func() {
+				Expect(result.Status).To(Equal(tasks.Success))
+			})
+			It("Should return a None result summary", func() {
+				Expect(result.Summary).To(Equal("Node agent identified as present on system"))
+			})
+		})
+	})
+})

--- a/tasks/node/env/dependencies.go
+++ b/tasks/node/env/dependencies.go
@@ -60,7 +60,7 @@ func (p NodeEnvDependencies) Execute(option tasks.Options, upstream map[string]t
 	if npmErr != nil && (npmErr.Error() != "exit status 1") {
 		return tasks.Result{
 			Status:      tasks.Error,
-			Summary:     npmErr.Error() + ": npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + tasks.ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors",
+			Summary:     npmErr.Error() + ": npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + tasks.ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors. The output of 'npm ls' is used by Support Engineers to find out if your application is using unsupported technologies.",
 			FilesToCopy: filesToCopy,
 		}
 	}
@@ -71,7 +71,7 @@ func (p NodeEnvDependencies) Execute(option tasks.Options, upstream map[string]t
 	if len(NodeModulesVersions) < 1 {
 		return tasks.Result{
 			Status:      tasks.Error,
-			Summary:     "We failed to parse the output of npm ls, but have included it in nrdiag-output.zip",
+			Summary:     "We failed to parse the output of npm ls, but have included it in nrdiag-output.zip. The output of 'npm ls' is used by Support Engineers to find out if your application is using unsupported technologies.",
 			FilesToCopy: filesToCopy,
 		}
 	}

--- a/tasks/node/env/dependencies_test.go
+++ b/tasks/node/env/dependencies_test.go
@@ -104,7 +104,7 @@ var _ = Describe("Node/Env/Dependencies", func() {
 				Expect(result.Status).To(Equal(tasks.Error))
 			})
 			It("Should return a Failure result summary", func() {
-				Expect(result.Summary).To(Equal("an error message: npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + tasks.ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors"))
+				Expect(result.Summary).To(Equal("an error message: npm throwed an error while running the command npm ls --depth=0 --parseable=true --long=true. Please verify that the " + tasks.ThisProgramFullName + " is running in your Node application directory. Possible causes for npm errors: https://docs.npmjs.com/common-errors. The output of 'npm ls' is used by Support Engineers to find out if your application is using unsupported technologies."))
 			})
 		})
 		Context("When NodeModulesVersions length is zero", func() {
@@ -128,7 +128,7 @@ var _ = Describe("Node/Env/Dependencies", func() {
 				Expect(result.Status).To(Equal(tasks.Error))
 			})
 			It("Should return a Error result summary", func() {
-				Expect(result.Summary).To(Equal("We failed to parse the output of npm ls, but have included it in nrdiag-output.zip"))
+				Expect(result.Summary).To(Equal("We failed to parse the output of npm ls, but have included it in nrdiag-output.zip. The output of 'npm ls' is used by Support Engineers to find out if your application is using unsupported technologies."))
 			})
 		})
 		Context("When getModulesList returns a succesful output that we pass to tasks.FileCopyEnvelope", func() {


### PR DESCRIPTION
# Issue
As I study new tickets where nrdiag task fails to do its job, then I do my best to update the task so it will not fail in the future.

Recently I found a Node agent support ticket(https://newrelic.zendesk.com/agent/tickets/441655) where nrdiag failed for two tasks:

1) Base/Config/Collect: it should have thrown a warning or failure status because we did not collect a config file for the node agent. The reason we didn't notice this was a problem is because we did not take into account the env var users can configure to not use a config file: `NEW_RELIC_NO_CONFIG_FILE`.

2)Node/Config/Agent: We did not run many Node agent tasks they will only if Node/Config/Agent succeeds. Node/Config/Agent fails when it does not find a config file, but that is not a fair way to judge if a user has configured the node agent because they can skip using a config file, and configure through env vars.

# Goals
1) Account for `NEW_RELIC_NO_CONFIG_FILE` in Base/Config/Collect and warn the customer that we were unable to collect a config file because they set this env var to true. 

2) Also, I seize the opportunity that I was working on this task to make an unrelated but needed change. 
I am adding a check for when users say "no" to nrdiag collecting secure config files: https://github.com/newrelic/newrelic-diagnostics-cli/blob/cc7a3a882df4b1f98c1c30565901fcc64fa73639/tasks/base/config/collect.go#L201
This information can be relevant for TSE to understand that nrdiag did not fail at collecting a secure config file, but it was the user that reject us collecting the config file.

3) Updating `Node/Config/Agent` to not rely on the presence of a config file but also look for the following env vars to know that the user is attempting to configure the node agent: https://github.com/newrelic/newrelic-diagnostics-cli/blob/cc7a3a882df4b1f98c1c30565901fcc64fa73639/tasks/node/config/agent.go#L23 . These are the minimum env vars user will need to configure, any other env vars are optional.

I consulted with the Node agent engineers to make sure that the env var `NEW_RELIC_NO_CONFIG_FILE` is only used by the Node agent. If it was used by other agents then this task will mistakenly assume that we are in a node environment when in fact we are in another agent environment that happens to use the same env vars.

# Implementation Details

# How to Test
This task should smoke tested by building the binary `go build` with this branch and then dropping the binary in a node application that has the node agent installed. The node agent should not use a config file but use the env vars mentioned here https://github.com/newrelic/newrelic-diagnostics-cli/blob/cc7a3a882df4b1f98c1c30565901fcc64fa73639/tasks/node/config/agent.go#L23  
For more details on how to configure the Node agent: https://docs.newrelic.com/docs/agents/nodejs-agent/installation-configuration/nodejs-agent-configuration 
Then run the nrdiag node tasks with the flag `suites`: ./newrelic-diagnostics-cli -suites node