### PR TITLE
only capture valid account License Keys and not Ingest keys

### DIFF
--- a/usage/usage.go
+++ b/usage/usage.go
@@ -232,7 +232,7 @@ func prepareMeta(results []registration.TaskResult, runID string) metaData {
 			runTimeMetaData.RpmApps = getRPMdetails(result.Result)
 		}
 
-		if result.Task.Identifier().String() == "Base/Config/ValidateLicenseKey" && (result.Result.Status == tasks.Success || result.Result.Status == tasks.Warning) {
+		if result.Task.Identifier().String() == "Base/Config/ValidateLicenseKey" && result.Result.Status == tasks.Success {
 			licenseKeyToSources, ok := result.Result.Payload.(map[string][]string)
 			//We do not need the value of sources(if lk is env var or comes from config file, etc) for this operation
 			reducedLicenseKeys := []string{}


### PR DESCRIPTION
# Issue
Usage data for nrLicenseKey will send any License keys that passes our format check:
https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/tasks/base/config/validateLicenseKey.go#L152
https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/tasks/base/config/validateLicenseKey.go#L140
Regardless if they are valid or not for a new relic account: https://github.com/newrelic/newrelic-diagnostics-cli/blob/main/tasks/base/config/validateLicenseKey.go#L93
Meaning if a License key is an Ingest key, it will pass the format check and but it will fail the validation against the account, so this usage data will send to Haberdasher.
Originally I thought this should be fine, I do want to collect usage data on Ingest keys. However, I forgot that Haberdasher will also collect new relic error when LK is not found for an account. So as Ingest Keys become popular, then Haberdasher will increase its amount of errors and we will constantly alert us on this issue/error increase.

# Goals
To only collect usage data on License keys that passed the validation against the account so Haberdasher will not collect errors because of Ingest Keys.

# Implementation Details
The change was not made on the task itself(ValidateLicenseKey.go) because it is `usage.go` that decides what payloads get send to Haberdasher.

# How to Test