### PR TITLE
fix(attach): replace s3 url env var check with s3 domain string

### DIFF
--- a/attach.go
+++ b/attach.go
@@ -40,6 +40,7 @@ type jsonResponse struct {
 const ticketAttachmentUploadTimeoutSeconds = 600
 const awsUploadTimeoutSeconds = 7200
 const defaultAttachmentEndpoint = "http://localhost:3000/attachments"
+const awsS3Domain = "s3.amazonaws.com"
 
 func getAttachmentsEndpoint() string {
 	if config.Flags.AttachmentEndpoint != "" { //If local development flag is supplied
@@ -152,7 +153,7 @@ func uploadFilelist(attachmentKey string, filelist []uploadFiles) {
 	var filesForTicketAttachment, filesForAWS []uploadFiles
 
 	for _, upload := range filelist {
-		if strings.Contains(upload.URL, os.Getenv("S3_UPLOAD_URL")) {
+		if strings.Contains(upload.URL, awsS3Domain) {
 			filesForAWS = append(filesForAWS, upload)
 		} else {
 			filesForTicketAttachment = append(filesForTicketAttachment, upload)


### PR DESCRIPTION
# Issue

All upload attachments were having their requests formed as if it were for s3. The diagnostics service endpoint likewise receiving invalid PUTs to its upload endpoint. 

This looks to be due to the check to determine if the upload URL supplied by the diagnostics service is an s3 URL by seeing if the URL contains the known s3 host for attachments supplied by an ENV var `S3_UPLOAD_URL`. Issue here is env var is likely to never be present in local environments in usage, or is a config var supplied at build time so the match always succeeds as an empty string.

# Goals

Fix match to s3 hostname

# Implementation Details

There are two paths here

- Set `S3_UPLOAD_URL` as an application config var and inject that value in the build arguments as we do with other config values.
- Match to a string for the s3 domain s3.amazonaws.com

I went for the second option here as the diagnostics-cli doesn't really need to know the s3 bucket to upload attachments to, that is always supplied on demand by the diagnostics service in the upload_url response. What it does need to determine is that it's an aws s3 url, which can be a done by a simple string match of the url to `s3.amazonaws.com` which also leaves flexibility for diagnostics service to change subdomains if need be.

# How to Test

- Run diagnostics with an attachment key argument to see files attached as normal ticket attachments
- Run diagnostics with an attachment key argument and `-file-upload` arg pointed to a >20 MB file to verify upload to s3