### PR TITLE
fix(upload): add env AWS_EC2_METADATA_DISABLED to upload script

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -11,7 +11,6 @@ then
   ./scripts/build.sh
 
   VERSION=`cat releaseVersion.txt| awk -F'majorMinor=' '{printf$2}'`
-
   ZIPFILENAME="nrdiag_${VERSION}.${BUILD_NUMBER}.zip"
 
   echo "Creating zipfile ${ZIPFILENAME}"
@@ -24,6 +23,8 @@ then
   zip -r $ZIPFILENAME nrdiag/
   echo "Uploading to Download.Newrelic.com"
   ln -s $ZIPFILENAME nrdiag_latest.zip
+
+  AWS_EC2_METADATA_DISABLED=true
 
   aws s3 cp ${ZIPFILENAME} s3://${S3_BUCKET}/nrdiag/
   aws s3 cp nrdiag_latest.zip s3://${S3_BUCKET}/nrdiag/


### PR DESCRIPTION
# Issue

Release publishing seems to have broken from the github actions migration of the ubuntu-latest image from 18.04 => 20.04 which uses v2 of the aws CLI 

Background:

https://github.com/aws/aws-cli/issues/5262
https://github.com/actions/virtual-environments/issues/1816


# Goals

# Implementation Details

This PR implements a suggested fix mentioned here:
https://github.com/aws/aws-cli/issues/5623#issuecomment-801240811

If this fails to work we can specify the image to ubuntu 18.04 in a follow up PR and allow more time to investigate

# How to Test