### PR TITLE
fix(release): set release github action to explicitly use ubuntu 18.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v.')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Install Go
         uses: actions/setup-go@v2
@@ -30,13 +30,10 @@ jobs:
           STAGING_ATTACHMENT_ENDPOINT: ${{ secrets.STAGING_ATTACHMENT_ENDPOINT }}
           STAGING_HABERDASHER_URL: ${{ secrets.STAGING_HABERDASHER_URL }}
         run: |
-            echo "release with following build version:"
-            echo ${{ github.event.release.name }}
-            BUILD_NUMBER=${{ github.event.release.name }} ./scripts/upload.sh
+          echo "release with following build version:"
+          echo ${{ github.event.release.name }}
+          BUILD_NUMBER=${{ github.event.release.name }} ./scripts/upload.sh
       - name: Debug GitHub context
         env:
           GITHUB_CONTEXT: ${{ toJson(github) }}
         run: echo "$GITHUB_CONTEXT"
-
-
-

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -24,7 +24,6 @@ then
   echo "Uploading to Download.Newrelic.com"
   ln -s $ZIPFILENAME nrdiag_latest.zip
 
-  AWS_EC2_METADATA_DISABLED=true
 
   aws s3 cp ${ZIPFILENAME} s3://${S3_BUCKET}/nrdiag/
   aws s3 cp nrdiag_latest.zip s3://${S3_BUCKET}/nrdiag/


### PR DESCRIPTION
# Issue

Release publishing seems to have broken from the github actions migration of the ubuntu-latest image from 18.04 => 20.04 which uses v2 of the aws CLI

Background:

aws/aws-cli#5262
actions/virtual-environments#1816

Follow up to : https://github.com/newrelic/newrelic-diagnostics-cli/pull/81

# Goals

Pin the release action to ubuntu 18.04 until we can purposefully migrate a solution to ubuntu 20.04

# Implementation Details

# How to Test