### PR TITLE
update ohi case validation for ohis v4

### DIFF
--- a/tasks/infra/config/integrationsValidateJson.go
+++ b/tasks/infra/config/integrationsValidateJson.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks/base/config"
@@ -75,7 +76,7 @@ func (p InfraConfigIntegrationsValidateJson) Execute(options tasks.Options, upst
 			yamlInMapCount++
 			//Loop through its respective keys in yamlKeyMap
 			for _, field := range yamlKeyMap[yamlFile.Config.FileName] {
-				foundFields := yamlFile.ParsedResult.FindKey(field)
+				foundFields := yamlFile.ParsedResult.FindKey(strings.ToLower(field))
 				//Validate json value, if invalid, append to invalidJson array
 				for _, key := range foundFields {
 					jsonValue := key.Value()


### PR DESCRIPTION
Small update to json validation of OHIS as the recommended way is to pass keys in uppercase.
This PR allow json validation to be compatible with the new and old format simply by lowercasing keys when comparing