### PR TITLE
Node v10 is now no longer compatible with New Relic Node.js Agent ver…

### DIFF
--- a/tasks/compatibilityVars/versions.go
+++ b/tasks/compatibilityVars/versions.go
@@ -65,7 +65,7 @@ var SupportedForJavaAgent4 = map[string][]string{
 
 var NodeSupportedVersions = map[string][]string{
 	"12": []string{"6.0.0+"},
-	"10": []string{"4.6.0+"},
+	"10": []string{"4.6.0-7.*"},
 }
 
 //https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework#net-version

--- a/tasks/node/env/versionCompatibility_test.go
+++ b/tasks/node/env/versionCompatibility_test.go
@@ -78,11 +78,11 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 10, 
-							Minor: 0, 
-							Patch: 0, 
+							Major: 10,
+							Minor: 0,
+							Patch: 0,
 							Build: 0,
 						},
 					},
@@ -131,20 +131,20 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 10, 
-							Minor: 6, 
-							Patch: 7, 
+							Major: 10,
+							Minor: 6,
+							Patch: 7,
 							Build: 456,
 						},
 					},
 					"Node/Agent/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 6, 
-							Minor: 0, 
-							Patch: 0, 
+							Major: 6,
+							Minor: 0,
+							Patch: 0,
 							Build: 0,
 						},
 					},
@@ -165,11 +165,11 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 11, 
-							Minor: 0, 
-							Patch: 0, 
+							Major: 11,
+							Minor: 0,
+							Patch: 0,
 							Build: 0,
 						},
 					},
@@ -195,11 +195,11 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 8, 
-							Minor: 0, 
-							Patch: 0, 
+							Major: 8,
+							Minor: 0,
+							Patch: 0,
 							Build: 0,
 						},
 					},
@@ -225,11 +225,11 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 10, 
-							Minor: 0, 
-							Patch: 0, 
+							Major: 10,
+							Minor: 0,
+							Patch: 0,
 							Build: 0,
 						},
 					},
@@ -255,11 +255,11 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 12, 
-							Minor: 0, 
-							Patch: 0, 
+							Major: 12,
+							Minor: 0,
+							Patch: 0,
 							Build: 0,
 						},
 					},
@@ -285,11 +285,11 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 					"Node/Env/Version": tasks.Result{
-						Status:  tasks.Info,
+						Status: tasks.Info,
 						Payload: tasks.Ver{
-							Major: 12, 
-							Minor: 0, 
-							Patch: 0, 
+							Major: 12,
+							Minor: 0,
+							Patch: 0,
 							Build: 0,
 						},
 					},
@@ -300,8 +300,68 @@ var _ = Describe("Node/Env/VersionCompatibility", func() {
 				}
 			})
 
-			It("should return an expected Warning for an odd version", func() {
+			It("should return an expected success for an odd version", func() {
 				Expect(result.Summary).To(Equal("Your current Node.js version, 12.0.0.0, is compatible with New Relic's Node.js agent"))
+			})
+		})
+
+		Context("When version 10 of Node.js is used with a valid Agent version", func() {
+
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Node/Env/Version": tasks.Result{
+						Status: tasks.Info,
+						Payload: tasks.Ver{
+							Major: 10,
+							Minor: 0,
+							Patch: 0,
+							Build: 0,
+						},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "7.0.0.0",
+					},
+				}
+			})
+
+			It("should return an expected success for a compatible version", func() {
+				Expect(result.Status).To(Equal(tasks.Success))
+			})
+
+			It("should return an expected successful message", func() {
+				Expect(result.Summary).To(Equal("Your current Node.js version, 10.0.0.0, is compatible with New Relic's Node.js agent"))
+			})
+		})
+
+		Context("When version 10 of Node.js is used with an incompatible Agent version", func() {
+
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Node/Env/Version": tasks.Result{
+						Status: tasks.Info,
+						Payload: tasks.Ver{
+							Major: 10,
+							Minor: 0,
+							Patch: 0,
+							Build: 0,
+						},
+					},
+					"Node/Agent/Version": tasks.Result{
+						Status:  tasks.Info,
+						Payload: "8.0.0.0",
+					},
+				}
+			})
+
+			It("should return an expected failure for a compatible version", func() {
+				Expect(result.Status).To(Equal(tasks.Failure))
+			})
+
+			It("should return an expected failure message", func() {
+				Expect(result.Summary).To(Equal("Your current Node.js version, 10.0.0.0, is not compatible with New Relic's Node.js agent"))
 			})
 		})
 	})


### PR DESCRIPTION
…sion 8.0.0.0+

# Issue
As stated [here](https://newrelic.atlassian.net/browse/IHUB-309), support for Node v10 is EOL for New Relic  Node.js Agents 8.0.0.0+.  This means that we need to change the compatibility functions of the Diagnostics tool in order to account for those changes.

# Goals
The goal is to change the compatibility for Node that is laid out in Diag.  This means going into our file where all of the version compatibility is stored and making a strict cutoff for the agent supportability for Node v10.  

# Implementation Details
In `tasks/compatibiltyVars/version.go`, we changed the `NodeSupportedVersions` for Node v10 to map to a range of supported New Relic Node.js Agent versions.  Previously, Node v10 mapped to `4.6.0+`, but now it maps to `4.6.0-7.*`.  This means it will support and Node.js Agent version below 8.0.0.0 (where it was EOL'd).  In order to make sure these changes worked, two unit tests were added to `tasks/node/env/versionCompatibility_test.go`.  These made sure that Node v10 with any Node.js Agent in the specified range would return a failure, while Node v10 with any Node.js Agent 8.0.0.0+ would return a success.

# How to Test
In `tasks/node/env/versionCompatibility_test.go` run the package tests to verify they pass.