### PR TITLE
Bumping the version to 2.0.0

### DIFF
--- a/releaseVersion.txt
+++ b/releaseVersion.txt
@@ -1,4 +1,4 @@
-majorMinor=1.12
-buildNumber=35
-currentReleaseVersion=1.12.35
-prevReleaseVersion=1.12.34
+majorMinor=2.0
+buildNumber=0
+currentReleaseVersion=2.0.0
+prevReleaseVersion=1.12.35


### PR DESCRIPTION
# Issue
For the next release of NRDiag we need to bump the version to 2.0.0

# Goals
New version of NRDiag

# Implementation Details
Changed releaseVersion.txt to reflect change

# How to Test
Hopefully when we publish it works