### PR TITLE
Update .NET version compatibility variables

### DIFF
--- a/tasks/compatibilityVars/versions.go
+++ b/tasks/compatibilityVars/versions.go
@@ -71,7 +71,6 @@ var NodeSupportedVersions = map[string][]string{
 //https://docs.newrelic.com/docs/agents/net-agent/getting-started/net-agent-compatibility-requirements-net-framework#net-version
 // .NET framework as keys and .NET agent as values
 var DotnetFrameworkSupportedVersions = map[string][]string{
-	"5.0": []string{"7.0.0+"},
 	"4.8": []string{"7.0.0+"},
 	"4.7": []string{"7.0.0+"},
 	"4.6": []string{"7.0.0+"}, //should be inclusive of version such as 4.6.1
@@ -88,6 +87,7 @@ var DotnetFrameworkOldVersions = map[string][]string{
 //.NET Core 2.0 or higher is supported by the New Relic .NET agent version 6.19 or higher
 
 var DotnetCoreSupportedVersions = map[string][]string{
+	"6.0": []string{"9.2.0+"},
 	"5.0": []string{"8.35.0+"},
 	"3.1": []string{"8.21.34.0+"},
 	"3.0": []string{"8.21.34.0+"},


### PR DESCRIPTION
# Issue

https://newrelic.atlassian.net/browse/IHEDIAG-65 

# Goals

Update the compatibility variables for .NET

# Implementation Details

I removed 5.0 from the .net framework variables as there is no .net framework 5.0 (.net 5 is .net core, [.net framework 4.8 is the last version of .net framework.](https://docs.microsoft.com/en-us/dotnet/framework/whats-new/))

I added .net 6 to the .net core variables

# Testing

This is covered by existing tests