### PR TITLE
Resolve workflow issues

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Test
         run: ./scripts/integrationTest.sh
   windows:
-    runs-on: windows-latest
+    runs-on: windows-2019
     steps:
       - name: Install Go
         uses: actions/setup-go@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          version: v1.45
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 


### PR DESCRIPTION
# Issue

* golangci workflow action is failing due to being on an old version
* windows integration test is failing due to using the workflow `windows-latest` (which is 2022) while our tests us windows 2019.

# Goals

* Have workflows run without error

# Implementation Details

* Update golangci to 1.45.2
* Pin the windows integration workflow to windows 2019

# How to Test