### PR TITLE
chore: Update the upload script to clean up the oldest release

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -31,3 +31,15 @@ fi
 if rm -r ./bin/ 2> /dev/null
   then echo "...removed bin directory"
 fi
+
+for file in ./nrdiag*.zip; do
+  if rm -r "$file" 2> /dev/null; then
+    echo "...removed $file"
+  fi
+done
+
+for file in ./nrdiag*/; do
+  if rm -r "$file" 2> /dev/null; then
+    echo "...removed $file"
+  fi
+done

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -28,6 +28,13 @@ then
   aws s3 cp ${ZIPFILENAME} s3://${S3_BUCKET}/nrdiag/
   aws s3 cp nrdiag_latest.zip s3://${S3_BUCKET}/nrdiag/
   aws s3 cp bin/version.txt s3://${S3_BUCKET}/nrdiag/
+
+  echo "Finding oldest release on download.newrelic.com"
+  OLD_RELEASE=$(aws s3api list-objects-v2 --bucket ${S3_BUCKET} --prefix nrdiag/ --query 'sort_by(Contents[?Key && contains(Key, `.zip`) == `true` && contains(Key, `nrdiag`) == `true`], &LastModified)[:1].[Key]' --output text)
+
+  echo "Oldest Release found: ${OLD_RELEASE}"
+  echo "Deleting ${OLD_RELEASE}"
+  aws s3 rm s3://${S3_BUCKET}/${OLD_RELEASE}
   
 else
   echo "The input passed for github.event.release.name was not a valid number. The release process did not run."


### PR DESCRIPTION
# Issue

https://newrelic.atlassian.net/browse/IHEDIAG-74

# Goals

Ensure only the last 2 versions are available for download at https://download.newrelic.com/nrdiag 

# Implementation Details

Updated upload.sh to include aws commands to find the oldest object and remove it.
Updated clean.sh to better clean up tests from upload.sh

# How to Test

I manually tested the script with a test bucket