### PR TITLE
feat: Build for arm64 and optimize binary size

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,8 +12,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-           - 1.13.x
-          #  - 1.14.x
+           - 1.18.x
         platform:
           - ubuntu-latest
           - macos-latest

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -29,7 +29,7 @@ fi
 VERSION=$(cat releaseVersion.txt | awk -F'majorMinor=' '{printf$2}')
 
 BUILD_TIMESTAMP=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
-LDFLAGS="-X ${CONFIG_PATH}.Version=${VERSION}.${VERSION_NUMBER} -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.UsageEndpoint=${USAGE_ENDPOINT} -X ${CONFIG_PATH}.AttachmentEndpoint=${ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.HaberdasherURL=${HABERDASHER_URL}"
+LDFLAGS="-s -w -X ${CONFIG_PATH}.Version=${VERSION}.${VERSION_NUMBER} -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.UsageEndpoint=${USAGE_ENDPOINT} -X ${CONFIG_PATH}.AttachmentEndpoint=${ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.HaberdasherURL=${HABERDASHER_URL}"
 
 # Set version based on version.txt file and auto version number
 echo "Build version is $VERSION.$VERSION_NUMBER"
@@ -45,6 +45,10 @@ echo "Building Mac x64 $EXENAME"
 GOOS=darwin GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
 $(mv "$EXENAME" "bin/mac/${EXENAME}_x64")
 
+echo "Building Mac arm64 $EXENAME"
+GOOS=darwin GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
+$(mv "$EXENAME" "bin/mac/${EXENAME}_arm64")
+
 echo "Building Linux 386"
 GOOS=linux GOARCH=386 go build -o "$EXENAME" -ldflags "$LDFLAGS"
 $(mv "$EXENAME" "bin/linux/$EXENAME")
@@ -52,6 +56,10 @@ $(mv "$EXENAME" "bin/linux/$EXENAME")
 echo "Building Linux x64"
 GOOS=linux GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
 $(mv "$EXENAME" "bin/linux/${EXENAME}_x64")
+
+echo "Building Linux arm64"
+GOOS=linux GOARCH=arm64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
+$(mv "$EXENAME" "bin/linux/${EXENAME}_arm64")
 
 echo "Building Windows 386"
 GOOS=windows GOARCH=386 go build -o "$EXENAME" -ldflags "$LDFLAGS"
@@ -61,3 +69,6 @@ echo "Building Windows x64"
 GOOS=windows GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
 $(mv "$EXENAME" "bin/win/${EXENAME}_x64.exe")
 
+echo "Building Windows arm64"
+GOOS=windows GOARCH=arm64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
+$(mv "$EXENAME" "bin/win/${EXENAME}_arm64.exe")


### PR DESCRIPTION
# Issue

We don't support arm64.

# Goals

Support arm64

# Implementation Details

Added build commands to build for arm64 for all 3 os's
Added `-s -w` to ldflags to remove debug info/symbols and reduce binary size (resulted in a 29.5% reduction in size!)

# How to Test

I have an arm based ec2 instance I tested with