### PR TITLE
include infra agent log gz files (#1)

### DIFF
--- a/tasks/infra/log/collect_test.go
+++ b/tasks/infra/log/collect_test.go
@@ -240,13 +240,13 @@ If you are working with a support ticket, manually provide your New Relic log fi
 
 		})
 	})
-	Describe("getLogFilePaths()", func() {
+	Describe("getLogFilePaths() with old log file configuration option", func() {
 		var (
 			result            []string
 			parsedConfigFiles []config.ValidateElement
 		)
 		JustBeforeEach(func() {
-			result = getLogFilePaths(parsedConfigFiles)
+			result = p.getLogFilePaths(parsedConfigFiles)
 		})
 		Context("When given a slice of validate elements containing log file entries", func() {
 			parsedConfigFiles = []config.ValidateElement{
@@ -263,6 +263,47 @@ If you are working with a support ticket, manually provide your New Relic log fi
 			}
 			It("Should return a slice of log_file paths", func() {
 				expectedResult := []string{"/var/log/messages"}
+				Expect(result).To(Equal(expectedResult))
+			})
+		})
+
+	})
+	Describe("getLogFilePaths() with new log file configuration option", func() {
+		var (
+			result            []string
+			parsedConfigFiles []config.ValidateElement
+		)
+		JustBeforeEach(func() {
+			result = p.getLogFilePaths(parsedConfigFiles)
+		})
+		Context("When given a slice of validate elements containing log file entries", func() {
+			parsedConfigFiles = []config.ValidateElement{
+				config.ValidateElement{
+					Config: config.ConfigElement{
+						FileName: "newrelic-infra.yml",
+						FilePath: "/etc/",
+					},
+					ParsedResult: tasks.ValidateBlob{
+						Key:      "log/file",
+						RawValue: "/var/log/newrelic-infra/newrelic-infra.log",
+					},
+				},
+			}
+			p.findFiles = func([]string, []string) []string {
+				return []string{
+					"/var/log/newrelic-infra/newrelic-infra.log",
+					"/var/log/newrelic-infra/newrelic-infra_2022-07-15_11-12-04.log",
+					"/var/log/newrelic-infra/newrelic-infra_2022-07-15_12-12-03.log",
+					"/var/log/newrelic-infra/newrelic-infra_2022-07-11_12-12-03.log.gz",
+				}
+			}
+			It("Should return a slice of log_file paths", func() {
+				expectedResult := []string{
+					"/var/log/newrelic-infra/newrelic-infra.log",
+					"/var/log/newrelic-infra/newrelic-infra_2022-07-15_11-12-04.log",
+					"/var/log/newrelic-infra/newrelic-infra_2022-07-15_12-12-03.log",
+					"/var/log/newrelic-infra/newrelic-infra_2022-07-11_12-12-03.log.gz",
+				}
 				Expect(result).To(Equal(expectedResult))
 			})
 		})

--- a/tasks/infra/log/log.go
+++ b/tasks/infra/log/log.go
@@ -11,5 +11,6 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 	registrationFunc(InfraLogLevelCheck{}, true)
 	registrationFunc(InfraLogCollect{
 		validatePaths: tasks.ValidatePaths,
+		findFiles:     tasks.FindFiles,
 	}, true)
 }


### PR DESCRIPTION
# Issue

The infra-agent now supports build-in log rotation, which might create additional log files other than the one specified in the configuration. See: https://github.com/newrelic/infrastructure-agent/blob/master/assets/examples/infrastructure/newrelic-infra-template.yml.example#L159

# Goals

Add into nrdiag all infra-agent log files. 

# Implementation Details

Additionally to the log file specified in the log configuration, rotated filenames will be made with the file base name of the main one + date + gz extension (if compression is enabled)

# How to Test

Implementation relies on tasks.FindFiles function


NOTE: Marked as draft till infra-agent 1.28.0 is released.