### PR TITLE
feat: validate release date of current infra agent version

### DIFF
--- a/tasks/infra/agent/agent.go
+++ b/tasks/infra/agent/agent.go
@@ -1,12 +1,16 @@
 package agent
 
 import (
+	"net/http"
 	"runtime"
+	"time"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
 	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
+
+type requestFunc func(wrapper httpHelper.RequestWrapper) (*http.Response, error)
 
 // RegisterWith - will register any plugins in this package
 func RegisterWith(registrationFunc func(tasks.Task, bool)) {
@@ -14,7 +18,9 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 
 	registrationFunc(InfraAgentVersion{
 		runtimeOS:   runtime.GOOS,
+		now:         time.Now,
 		cmdExecutor: tasks.CmdExecutor,
+		httpGetter:  httpHelper.MakeHTTPRequest,
 	}, true)
 	registrationFunc(InfraAgentDebug{
 		blockWithProgressbar: blockWithProgressbar,

--- a/tasks/infra/agent/connect.go
+++ b/tasks/infra/agent/connect.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
 	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
@@ -16,9 +15,7 @@ type InfraAgentConnect struct {
 	httpGetter requestFunc
 }
 
-type requestFunc func(wrapper httpHelper.RequestWrapper) (*http.Response, error)
-
-//RequestResult - contains HTTP response and error status data, Id is to distinguish requests from many, in this case region
+// RequestResult - contains HTTP response and error status data, Id is to distinguish requests from many, in this case region
 type RequestResult struct {
 	Id         string
 	URL        string


### PR DESCRIPTION
# Issue

- Validate if the installed version of Infrastructure Agent is older than one or two years ago.

# Goals

- Display an error or warning depending on the result.

# Implementation Details

- Use the Github API to fetch the release date for that version. The current infra agent metadata does not include the build date.

# How to Test