### PR TITLE
fix: Updated linux integration test env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ replacement.txt
 .git.bfg-report/
 #Rusty hog
 hog.out
+#goenv
+.go-version

--- a/dockerHelper_test.go
+++ b/dockerHelper_test.go
@@ -44,7 +44,7 @@ func CreateDockerfile(imageName string, dockerFROM string, dockerCMD string, doc
 	}
 
 	baseDockerFrom := []string{
-		"FROM ubuntu:16.04",
+		"FROM ubuntu:22.04",
 		"RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get install -qqy unzip apt-transport-https ca-certificates",
 	}
 

--- a/scripts/integrationTest.sh
+++ b/scripts/integrationTest.sh
@@ -13,8 +13,8 @@ USAGE_ENDPOINT="${STAGING_USAGE_ENDPOINT}"
 ATTACHMENT_ENDPOINT="${STAGING_ATTACHMENT_ENDPOINT}"
 CONFIG_PATH="github.com/newrelic/newrelic-diagnostics-cli/config"
 
-echo "Building linux x86"
-GOOS=linux GOARCH=386 go build -o "$EXENAME" -ldflags "-X ${CONFIG_PATH}.Version=INTEGRATION -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.UsageEndpoint=${USAGE_ENDPOINT} -X ${CONFIG_PATH}.AttachmentEndpoint=${ATTACHMENT_ENDPOINT}"
+echo "Building linux x64"
+GOOS=linux GOARCH=amd64 go build -o "$EXENAME" -ldflags "-X ${CONFIG_PATH}.Version=INTEGRATION -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.UsageEndpoint=${USAGE_ENDPOINT} -X ${CONFIG_PATH}.AttachmentEndpoint=${ATTACHMENT_ENDPOINT}"
 mkdir -p bin/linux
 $(mv "$EXENAME" "bin/linux/$EXENAME")
 echo "Running integration tests"


### PR DESCRIPTION
# Issue

Integration tests are failing

# Implementation Details

Updated the linux integration tests to use x64 instead of x86, and bumped the ubuntu image up to 22.04. 

# How to Test

`./scripts/integrationTests.sh`