### PR TITLE
Permalinks to run

### DIFF
--- a/attach/attach.go
+++ b/attach/attach.go
@@ -103,11 +103,11 @@ func getFilesForUpload(identifyingKey string, timestamp string, filetype string,
 func uploadFilesToAccount(filesToUpload []UploadFiles, attachmentKey string, deps IAttachDeps) ([]string, error) {
 	var urlsToReturn []string
 	for _, files := range filesToUpload {
+		newUrl, err := uploadFile(files, attachmentKey, deps)
+		if err != nil {
+			return nil, err
+		}
 		if !strings.Contains(files.Filename, ".zip") {
-			newUrl, err := uploadFile(files, attachmentKey, deps)
-			if err != nil {
-				return nil, err
-			}
 			urlsToReturn = append(urlsToReturn, *newUrl)
 		}
 	}

--- a/attach/attach.go
+++ b/attach/attach.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
 	"github.com/newrelic/newrelic-diagnostics-cli/output/color"
@@ -130,7 +131,9 @@ func uploadFilesToAccount(filesToUpload []UploadFiles, attachmentKey string, dep
 		if marshallErr != nil {
 			return nil, marshallErr
 		}
-		urlsToReturn = append(urlsToReturn, bodyJson.URL)
+		if !strings.Contains(files.Filename, ".zip") {
+			urlsToReturn = append(urlsToReturn, bodyJson.URL)
+		}
 
 	}
 	return urlsToReturn, nil

--- a/attach/attach_test.go
+++ b/attach/attach_test.go
@@ -2,22 +2,18 @@ package attach
 
 import (
 	"bytes"
-	"encoding/json"
+	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
 
-	"github.com/gorilla/mux"
-	"github.com/newrelic/newrelic-diagnostics-cli/config"
 	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
 	"github.com/newrelic/newrelic-diagnostics-cli/mocks"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/assert"
+
+	"github.com/stretchr/testify/mock"
 )
 
 var testServer *httptest.Server
@@ -25,9 +21,12 @@ var testServer *httptest.Server
 func setup() {
 	testServer = httptest.NewServer((http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/success") {
+			fmt.Println("HERHEREHRERHERE")
 			w.WriteHeader(200)
 		}
 		if strings.Contains(r.URL.Path, "/error") {
+			fmt.Println("NONONONOONONO")
+
 			w.WriteHeader(500)
 		}
 	})))
@@ -37,50 +36,41 @@ func teardown() {
 	testServer.Close()
 }
 
-func TestUpload(t *testing.T) {
+// func TestUpload(t *testing.T) {
+// 	setup()
+// 	defer teardown()
+// 	type args struct {
+// 		identifyingKey string
+// 		timestamp      string
+// 		dependencies   IAttachDeps
+// 	}
+// 	tests := []struct {
+// 		name     string
+// 		args     args
+// 		endpoint string
+// 	}{
+// 		{
+// 			name: "Test successful Upload",
+// 			args: args{
+// 				identifyingKey: "TestKey",
+// 				timestamp:      "TimestampTest",
+// 				dependencies:   mocks.MAttachDeps{},
+// 			},
+// 			endpoint: "/success",
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			config.AttachmentEndpoint = testServer.URL + tt.endpoint
+// 			Upload(tt.args.identifyingKey, tt.args.timestamp, tt.args.dependencies)
+// 		})
+// 	}
+// }
+
+func Test_uploadFile(t *testing.T) {
 	setup()
 	defer teardown()
-	type args struct {
-		identifyingKey string
-		timestamp      string
-		dependencies   IAttachDeps
-	}
-	tests := []struct {
-		name     string
-		args     args
-		endpoint string
-	}{
-		{
-			name: "Test successful Upload",
-			args: args{
-				identifyingKey: "TestKey",
-				timestamp:      "TimestampTest",
-				dependencies:   mocks.MAttachDeps{},
-			},
-			endpoint: "/success",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config.AttachmentEndpoint = testServer.URL + tt.endpoint
-			Upload(tt.args.identifyingKey, tt.args.timestamp, tt.args.dependencies)
-		})
-	}
-}
 
-func Test_uploadFilesToAccount(t *testing.T) {
-	setup()
-	defer teardown()
-
-	var files []UploadFiles
-	zipfile := UploadFiles{
-		Path:        "/",
-		Filename:    "file1.zip",
-		NewFilename: "file1-timestamp.zip",
-		Filesize:    4,
-		URL:         "",
-		Key:         "testKey",
-	}
 	jsonfile := UploadFiles{
 		Path:        "/",
 		Filename:    "file1.json",
@@ -89,400 +79,515 @@ func Test_uploadFilesToAccount(t *testing.T) {
 		URL:         "",
 		Key:         "testKey",
 	}
-	files = append(files, zipfile)
-	files = append(files, jsonfile)
+	wantedUrl := "https://newrelic.com"
+	type MockGetReaderRet struct {
+		byts *bytes.Reader
+		err  error
+	}
+	type MockGetUrlsToReturnRet struct {
+		url *string
+		err error
+	}
+	type MockReturns struct {
+		getFileSize     int64
+		getReader       MockGetReaderRet
+		getWrapper      httpHelper.RequestWrapper
+		getUrlsToReturn MockGetUrlsToReturnRet
+	}
 
 	type args struct {
-		filesToUpload []UploadFiles
+		filesToUpload UploadFiles
 		attachmentKey string
-		deps          IAttachDeps
 	}
 	tests := []struct {
-		name     string
-		args     args
-		wantErr  bool
-		endpoint string
+		name        string
+		args        args
+		wantErr     bool
+		want        *string
+		mockReturns MockReturns
 	}{
 		{
 			name: "Test successful uploadFilesToAccount",
 			args: args{
-				filesToUpload: files,
-				attachmentKey: "testKey",
-				deps:          mocks.MAttachDeps{},
-			},
-			wantErr:  false,
-			endpoint: "/success",
-		},
-		{
-			name: "Test failed uploadFilesToAccount",
-			args: args{
-				filesToUpload: files,
-				attachmentKey: "testKey",
-				deps:          mocks.MAttachDeps{},
-			},
-			wantErr:  true,
-			endpoint: "/error",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config.AttachmentEndpoint = testServer.URL + tt.endpoint
-			if err := uploadFilesToAccount(tt.args.filesToUpload, tt.args.attachmentKey, tt.args.deps); (err != nil) != tt.wantErr {
-				t.Errorf("uploadFilesToAccount() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
-
-func TestAttachDeps_getAttachmentsEndpoint(t *testing.T) {
-	tests := []struct {
-		name                    string
-		attachmentEndpoint      string
-		flagsAttachmentEndpoint string
-		want                    string
-	}{
-		{
-			name:                    "Test GetAttachmentEndpoint none set",
-			attachmentEndpoint:      "",
-			flagsAttachmentEndpoint: "",
-			want:                    "http://localhost:3000/attachments",
-		},
-		{
-			name:                    "Test GetAttachmentEndpoint config.Flags.AttachmentEndpoint set",
-			attachmentEndpoint:      "",
-			flagsAttachmentEndpoint: "http://diag.datanerd.us/attachments",
-			want:                    "http://diag.datanerd.us/attachments",
-		},
-		{
-			name:                    "Test GetAttachmentEndpoint config.AttachmentEndpoint set",
-			attachmentEndpoint:      "http://diag.datanerd.us/attachments",
-			flagsAttachmentEndpoint: "",
-			want:                    "http://diag.datanerd.us/attachments",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config.Flags.AttachmentEndpoint = tt.flagsAttachmentEndpoint
-			config.AttachmentEndpoint = tt.attachmentEndpoint
-			if got := getAttachmentsEndpoint(); got != tt.want {
-				t.Errorf("AttachDeps.GetAttachmentsEndpoint() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestAttachDeps_GetWrapper(t *testing.T) {
-	type args struct {
-		file          *bytes.Reader
-		fileSize      int64
-		filename      string
-		attachmentKey string
-	}
-	mockAttachDeps := mocks.MAttachDeps{}
-	mockFile, _ := mockAttachDeps.GetReader("")
-	tests := []struct {
-		name string
-		args args
-		want httpHelper.RequestWrapper
-	}{
-		{
-			name: "Test GetWrapper",
-			args: args{
-				file:          mockFile,
-				fileSize:      mockFile.Size(),
-				filename:      "mockFile",
+				filesToUpload: jsonfile,
 				attachmentKey: "testKey",
 			},
-			want: httpHelper.RequestWrapper{
-				Method:         "POST",
-				URL:            "http://localhost:3000/attachments/upload_s3?filename=mockFile",
-				Headers:        map[string]string{"Attachment-Key": "testKey"},
-				Payload:        mockFile,
-				Length:         mockFile.Size(),
-				TimeoutSeconds: 7200,
-				BypassProxy:    false,
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config.Flags.AttachmentEndpoint = ""
-			config.AttachmentEndpoint = ""
-			if got := getWrapper(tt.args.file, tt.args.fileSize, tt.args.filename, tt.args.attachmentKey); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("AttachDeps.GetWrapper() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestAttachDeps_makeRequest(t *testing.T) {
-	setup()
-	defer teardown()
-	mockAttachDeps := mocks.MAttachDeps{}
-	mockFile, _ := mockAttachDeps.GetReader("")
-	type args struct {
-		wrapper httpHelper.RequestWrapper
-	}
-	tests := []struct {
-		name           string
-		args           args
-		wantStatusCode int
-		wantErr        bool
-	}{
-		{
-			name: "Test MakeRequest success",
-			args: args{
-				wrapper: httpHelper.RequestWrapper{
+			wantErr: false,
+			want:    &wantedUrl,
+			mockReturns: MockReturns{
+				getFileSize: 4,
+				getReader: MockGetReaderRet{
+					byts: bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					err:  nil,
+				},
+				getWrapper: httpHelper.RequestWrapper{
 					Method:         "POST",
 					URL:            testServer.URL + "/success",
-					Headers:        map[string]string{"Attachment-Key": "testKey"},
-					Payload:        mockFile,
-					Length:         mockFile.Size(),
-					TimeoutSeconds: 7200,
-					BypassProxy:    false,
+					Payload:        bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					Length:         4,
+					TimeoutSeconds: awsUploadTimeoutSeconds,
+					Headers:        map[string]string{"Attachment-Key": "123563454"},
+				},
+				getUrlsToReturn: MockGetUrlsToReturnRet{
+					url: &wantedUrl,
+					err: nil,
 				},
 			},
-			wantStatusCode: 200,
-			wantErr:        false,
 		},
 		{
-			name: "Test MakeRequest fail",
+			name: "Test with Reader Error",
 			args: args{
-				wrapper: httpHelper.RequestWrapper{
+				filesToUpload: jsonfile,
+				attachmentKey: "testKey",
+			},
+			wantErr: true,
+			want:    nil,
+			mockReturns: MockReturns{
+				getFileSize: 4,
+				getReader: MockGetReaderRet{
+					byts: nil,
+					err:  errors.New("Error uploading at Reader"),
+				},
+				getWrapper: httpHelper.RequestWrapper{
 					Method:         "POST",
-					URL:            testServer.URL + "/error",
-					Headers:        map[string]string{"Attachment-Key": "testKey"},
-					Payload:        mockFile,
-					Length:         mockFile.Size(),
-					TimeoutSeconds: 7200,
-					BypassProxy:    false,
+					URL:            testServer.URL + "/success",
+					Payload:        bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					Length:         4,
+					TimeoutSeconds: awsUploadTimeoutSeconds,
+					Headers:        map[string]string{"Attachment-Key": "123563454"},
+				},
+				getUrlsToReturn: MockGetUrlsToReturnRet{
+					url: &wantedUrl,
+					err: nil,
 				},
 			},
-			wantStatusCode: 500,
-			wantErr:        true,
+		},
+		{
+			name: "Test with non 200 status code",
+			args: args{
+				filesToUpload: jsonfile,
+				attachmentKey: "testKey",
+			},
+			wantErr: true,
+			want:    nil,
+			mockReturns: MockReturns{
+				getFileSize: 4,
+				getReader: MockGetReaderRet{
+					byts: bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					err:  nil,
+				},
+				getWrapper: httpHelper.RequestWrapper{
+					Method:         "POST",
+					URL:            testServer.URL + "/error",
+					Payload:        bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					Length:         4,
+					TimeoutSeconds: awsUploadTimeoutSeconds,
+					Headers:        map[string]string{"Attachment-Key": "123563454"},
+				},
+				getUrlsToReturn: MockGetUrlsToReturnRet{
+					url: &wantedUrl,
+					err: nil,
+				},
+			},
+		},
+		{
+			name: "Test with url error",
+			args: args{
+				filesToUpload: jsonfile,
+				attachmentKey: "testKey",
+			},
+			wantErr: true,
+			want:    nil,
+			mockReturns: MockReturns{
+				getFileSize: 4,
+				getReader: MockGetReaderRet{
+					byts: bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					err:  nil,
+				},
+				getWrapper: httpHelper.RequestWrapper{
+					Method:         "POST",
+					URL:            testServer.URL + "/success",
+					Payload:        bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					Length:         4,
+					TimeoutSeconds: awsUploadTimeoutSeconds,
+					Headers:        map[string]string{"Attachment-Key": "123563454"},
+				},
+				getUrlsToReturn: MockGetUrlsToReturnRet{
+					url: nil,
+					err: errors.New("URL Error"),
+				},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := makeRequest(tt.args.wrapper)
+			mockAttachDeps := new(mocks.MAttachDeps)
+			mockAttachDeps.On("GetFileSize", mock.Anything).Return(tt.mockReturns.getFileSize)
+			mockAttachDeps.On("GetReader", mock.Anything).Return(tt.mockReturns.getReader.byts, tt.mockReturns.getReader.err)
+			mockAttachDeps.On("GetWrapper", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.mockReturns.getWrapper)
+			mockAttachDeps.On("GetUrlsToReturn", mock.Anything).Return(tt.mockReturns.getUrlsToReturn.url, tt.mockReturns.getUrlsToReturn.err)
+
+			got, err := uploadFile(tt.args.filesToUpload, tt.args.attachmentKey, mockAttachDeps)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("AttachDeps.MakeRequest() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("uploadFilesToAccount() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != nil {
-				if !reflect.DeepEqual(got.StatusCode, tt.wantStatusCode) {
-					t.Errorf("AttachDeps.MakeRequest() = %v, want %v", got, tt.wantStatusCode)
-					return
-				}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("uploadFilesToAccount() = %v, want %v", got, tt.want)
 			}
 		})
 	}
 }
 
-// Legacy tests below
+// func TestAttachDeps_getAttachmentsEndpoint(t *testing.T) {
+// 	tests := []struct {
+// 		name                    string
+// 		attachmentEndpoint      string
+// 		flagsAttachmentEndpoint string
+// 		want                    string
+// 	}{
+// 		{
+// 			name:                    "Test GetAttachmentEndpoint none set",
+// 			attachmentEndpoint:      "",
+// 			flagsAttachmentEndpoint: "",
+// 			want:                    "http://localhost:3000/attachments",
+// 		},
+// 		{
+// 			name:                    "Test GetAttachmentEndpoint config.Flags.AttachmentEndpoint set",
+// 			attachmentEndpoint:      "",
+// 			flagsAttachmentEndpoint: "http://diag.datanerd.us/attachments",
+// 			want:                    "http://diag.datanerd.us/attachments",
+// 		},
+// 		{
+// 			name:                    "Test GetAttachmentEndpoint config.AttachmentEndpoint set",
+// 			attachmentEndpoint:      "http://diag.datanerd.us/attachments",
+// 			flagsAttachmentEndpoint: "",
+// 			want:                    "http://diag.datanerd.us/attachments",
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			config.Flags.AttachmentEndpoint = tt.flagsAttachmentEndpoint
+// 			config.AttachmentEndpoint = tt.attachmentEndpoint
+// 			if got := getAttachmentsEndpoint(); got != tt.want {
+// 				t.Errorf("AttachDeps.GetAttachmentsEndpoint() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
 
-type Client struct {
-	cli *http.Client
-	URL string
-}
+// // func TestAttachDeps_GetWrapper(t *testing.T) {
+// // 	type args struct {
+// // 		file          *bytes.Reader
+// // 		fileSize      int64
+// // 		filename      string
+// // 		attachmentKey string
+// // 	}
+// // 	mockAttachDeps := mocks.MAttachDeps{}
+// // 	mockFile, _ := mockAttachDeps.GetReader("")
+// // 	tests := []struct {
+// // 		name string
+// // 		args args
+// // 		want httpHelper.RequestWrapper
+// // 	}{
+// // 		{
+// // 			name: "Test GetWrapper",
+// // 			args: args{
+// // 				file:          mockFile,
+// // 				fileSize:      mockFile.Size(),
+// // 				filename:      "mockFile",
+// // 				attachmentKey: "testKey",
+// // 			},
+// // 			want: httpHelper.RequestWrapper{
+// // 				Method:         "POST",
+// // 				URL:            "http://localhost:3000/attachments/upload_s3?filename=mockFile",
+// // 				Headers:        map[string]string{"Attachment-Key": "testKey"},
+// // 				Payload:        mockFile,
+// // 				Length:         mockFile.Size(),
+// // 				TimeoutSeconds: 7200,
+// // 				BypassProxy:    false,
+// // 			},
+// // 		},
+// // 	}
+// // 	for _, tt := range tests {
+// // 		t.Run(tt.name, func(t *testing.T) {
+// // 			config.Flags.AttachmentEndpoint = ""
+// // 			config.AttachmentEndpoint = ""
+// // 			if got := GetWrapper(tt.args.file, tt.args.fileSize, tt.args.filename, tt.args.attachmentKey); !reflect.DeepEqual(got, tt.want) {
+// // 				t.Errorf("AttachDeps.GetWrapper() = %v, want %v", got, tt.want)
+// // 			}
+// // 		})
+// // 	}
+// // }
 
-var _ = Describe("GetAttachmentEndpoints", func() {
-	var (
-		expectedResult string
-	)
-	Context("With no attachmentEndpointsSet", func() {
-		BeforeEach(func() {
-			config.Flags.AttachmentEndpoint = ""
-			config.AttachmentEndpoint = ""
-			expectedResult = "http://localhost:3000/attachments"
-		})
-		It("Should return default attachment endpoint (localhost)", func() {
-			result := getAttachmentsEndpoint()
-			Expect(result).To(Equal(expectedResult))
-		})
-	})
-	Context("With flag attachment endpoints set", func() {
-		BeforeEach(func() {
-			config.Flags.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
-			config.AttachmentEndpoint = ""
-			expectedResult = "http://diag.datanerd.us/attachments"
-		})
-		It("Should return flag attachment endpoint", func() {
-			result := getAttachmentsEndpoint()
-			Expect(result).To(Equal(expectedResult))
-		})
-	})
-	Context("With attachment endpoint set", func() {
-		BeforeEach(func() {
-			config.Flags.AttachmentEndpoint = ""
-			config.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
-			expectedResult = "http://diag.datanerd.us/attachments"
-		})
-		It("Should return attachment endpoint", func() {
-			result := getAttachmentsEndpoint()
-			Expect(result).To(Equal(expectedResult))
-		})
-	})
+// func TestAttachDeps_makeRequest(t *testing.T) {
+// 	setup()
+// 	defer teardown()
+// 	mockAttachDeps := mocks.MAttachDeps{}
+// 	mockFile, _ := mockAttachDeps.GetReader("")
+// 	type args struct {
+// 		wrapper httpHelper.RequestWrapper
+// 	}
+// 	tests := []struct {
+// 		name           string
+// 		args           args
+// 		wantStatusCode int
+// 		wantErr        bool
+// 	}{
+// 		{
+// 			name: "Test MakeRequest success",
+// 			args: args{
+// 				wrapper: httpHelper.RequestWrapper{
+// 					Method:         "POST",
+// 					URL:            testServer.URL + "/success",
+// 					Headers:        map[string]string{"Attachment-Key": "testKey"},
+// 					Payload:        mockFile,
+// 					Length:         mockFile.Size(),
+// 					TimeoutSeconds: 7200,
+// 					BypassProxy:    false,
+// 				},
+// 			},
+// 			wantStatusCode: 200,
+// 			wantErr:        false,
+// 		},
+// 		{
+// 			name: "Test MakeRequest fail",
+// 			args: args{
+// 				wrapper: httpHelper.RequestWrapper{
+// 					Method:         "POST",
+// 					URL:            testServer.URL + "/error",
+// 					Headers:        map[string]string{"Attachment-Key": "testKey"},
+// 					Payload:        mockFile,
+// 					Length:         mockFile.Size(),
+// 					TimeoutSeconds: 7200,
+// 					BypassProxy:    false,
+// 				},
+// 			},
+// 			wantStatusCode: 500,
+// 			wantErr:        true,
+// 		},
+// 	}
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			got, err := makeRequest(tt.args.wrapper)
+// 			if (err != nil) != tt.wantErr {
+// 				t.Errorf("AttachDeps.MakeRequest() error = %v, wantErr %v", err, tt.wantErr)
+// 				return
+// 			}
+// 			if got != nil {
+// 				if !reflect.DeepEqual(got.StatusCode, tt.wantStatusCode) {
+// 					t.Errorf("AttachDeps.MakeRequest() = %v, want %v", got, tt.wantStatusCode)
+// 					return
+// 				}
+// 			}
+// 		})
+// 	}
+// }
 
-})
+// // Legacy tests below
 
-var _ = Describe("buildGetRequestURL", func() {
-	var (
-		expectedResult string
-	)
-	Context("with filename, attachmentKey, and filesize set", func() {
-		BeforeEach(func() {
-			config.Flags.AttachmentEndpoint = ""
-			config.AttachmentEndpoint = ""
-			expectedResult = "http://localhost:3000/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t56789014&filename=nrdiag-output.json&filesize=23647"
-		})
-		It("Should return default attachment endpoint (localhost)", func() {
-			result := buildGetRequestURL("nrdiag-output.json", "1Q3OS5O1ffsd2345678901t56789014", 23647)
-			Expect(result).To(Equal(expectedResult))
-		})
-	})
+// type Client struct {
+// 	cli *http.Client
+// 	URL string
+// }
 
-})
+// var _ = Describe("GetAttachmentEndpoints", func() {
+// 	var (
+// 		expectedResult string
+// 	)
+// 	Context("With no attachmentEndpointsSet", func() {
+// 		BeforeEach(func() {
+// 			config.Flags.AttachmentEndpoint = ""
+// 			config.AttachmentEndpoint = ""
+// 			expectedResult = "http://localhost:3000/attachments"
+// 		})
+// 		It("Should return default attachment endpoint (localhost)", func() {
+// 			result := getAttachmentsEndpoint()
+// 			Expect(result).To(Equal(expectedResult))
+// 		})
+// 	})
+// 	Context("With flag attachment endpoints set", func() {
+// 		BeforeEach(func() {
+// 			config.Flags.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
+// 			config.AttachmentEndpoint = ""
+// 			expectedResult = "http://diag.datanerd.us/attachments"
+// 		})
+// 		It("Should return flag attachment endpoint", func() {
+// 			result := getAttachmentsEndpoint()
+// 			Expect(result).To(Equal(expectedResult))
+// 		})
+// 	})
+// 	Context("With attachment endpoint set", func() {
+// 		BeforeEach(func() {
+// 			config.Flags.AttachmentEndpoint = ""
+// 			config.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
+// 			expectedResult = "http://diag.datanerd.us/attachments"
+// 		})
+// 		It("Should return attachment endpoint", func() {
+// 			result := getAttachmentsEndpoint()
+// 			Expect(result).To(Equal(expectedResult))
+// 		})
+// 	})
 
-func TestGoodAttachmentUploadURL(t *testing.T) {
-	r := thisRouter(SuccessGetRequestAttachmentKey)
+// })
 
-	s := httptest.NewServer(r)
-	defer s.Close()
+// var _ = Describe("buildGetRequestURL", func() {
+// 	var (
+// 		expectedResult string
+// 	)
+// 	Context("with filename, attachmentKey, and filesize set", func() {
+// 		BeforeEach(func() {
+// 			config.Flags.AttachmentEndpoint = ""
+// 			config.AttachmentEndpoint = ""
+// 			expectedResult = "http://localhost:3000/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t56789014&filename=nrdiag-output.json&filesize=23647"
+// 		})
+// 		It("Should return default attachment endpoint (localhost)", func() {
+// 			result := buildGetRequestURL("nrdiag-output.json", "1Q3OS5O1ffsd2345678901t56789014", 23647)
+// 			Expect(result).To(Equal(expectedResult))
+// 		})
+// 	})
 
-	thisClient := &Client{
-		cli: s.Client(),
-		URL: s.URL,
-	}
-	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014R&filename=nrdiag-output.zip&filesize=23456"
-	expectedResponse := jsonResponse{
-		URL: "https://mock-bucket.s3.amazonaws.com/staging/tickets/543210/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-		Key: "tickets/543210/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-	}
+// })
 
-	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
-	if err != nil {
-		panic(err)
-	}
+// func TestGoodAttachmentUploadURL(t *testing.T) {
+// 	r := thisRouter(SuccessGetRequestAttachmentKey)
 
-	res, err := thisClient.cli.Do(req)
-	if err != nil {
-		panic(err)
-	}
+// 	s := httptest.NewServer(r)
+// 	defer s.Close()
 
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(res.Body)
-	if err != nil {
-		panic(err)
-	}
-	var MyResult jsonResponse
-	err = json.Unmarshal(buf.Bytes(), &MyResult)
-	if err != nil {
-		panic(err)
-	}
+// 	thisClient := &Client{
+// 		cli: s.Client(),
+// 		URL: s.URL,
+// 	}
+// 	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014R&filename=nrdiag-output.zip&filesize=23456"
+// 	expectedResponse := jsonResponse{
+// 		URL: "https://mock-bucket.s3.amazonaws.com/staging/tickets/543210/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+// 		Key: "tickets/543210/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+// 	}
 
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	assert.Equal(t, expectedResponse, MyResult)
-}
+// 	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-func TestBadAttachmentUploadURL(t *testing.T) {
-	r := thisRouter(FailureGetRequest)
+// 	res, err := thisClient.cli.Do(req)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	s := httptest.NewServer(r)
-	defer s.Close()
+// 	buf := new(bytes.Buffer)
+// 	_, err = buf.ReadFrom(res.Body)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	var MyResult jsonResponse
+// 	err = json.Unmarshal(buf.Bytes(), &MyResult)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	thisClient := &Client{
-		cli: s.Client(),
-		URL: s.URL,
-	}
-	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=badattachmentkey&filename=nrdiag-output.json&filesize=34256"
+// 	assert.Equal(t, http.StatusOK, res.StatusCode)
+// 	assert.Equal(t, expectedResponse, MyResult)
+// }
 
-	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
-	if err != nil {
-		panic(err)
-	}
+// func TestBadAttachmentUploadURL(t *testing.T) {
+// 	r := thisRouter(FailureGetRequest)
 
-	res, err := thisClient.cli.Do(req)
-	if err != nil {
-		panic(err)
-	}
+// 	s := httptest.NewServer(r)
+// 	defer s.Close()
 
-	assert.Equal(t, http.StatusNotFound, res.StatusCode)
-}
+// 	thisClient := &Client{
+// 		cli: s.Client(),
+// 		URL: s.URL,
+// 	}
+// 	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=badattachmentkey&filename=nrdiag-output.json&filesize=34256"
 
-func TestGoodLicenseUploadURL(t *testing.T) {
-	r := thisRouter(SuccessGetRequestLicenseKey)
+// 	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	s := httptest.NewServer(r)
-	defer s.Close()
+// 	res, err := thisClient.cli.Do(req)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	thisClient := &Client{
-		cli: s.Client(),
-		URL: s.URL,
-	}
-	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014RFf87AsS0&filename=nrdiag-output.json&filesize=23456"
-	expectedResponse := jsonResponse{
-		URL: "https://mock-bucket.s3.amazonaws.com/staging/accounts/123456789/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-		Key: "accounts/123456789/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-	}
+// 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+// }
 
-	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
-	if err != nil {
-		panic(err)
-	}
+// func TestGoodLicenseUploadURL(t *testing.T) {
+// 	r := thisRouter(SuccessGetRequestLicenseKey)
 
-	res, err := thisClient.cli.Do(req)
-	if err != nil {
-		panic(err)
-	}
+// 	s := httptest.NewServer(r)
+// 	defer s.Close()
 
-	buf := new(bytes.Buffer)
-	_, err = buf.ReadFrom(res.Body)
-	if err != nil {
-		panic(err)
-	}
-	var MyResult jsonResponse
-	err = json.Unmarshal(buf.Bytes(), &MyResult)
-	if err != nil {
-		panic(err)
-	}
+// 	thisClient := &Client{
+// 		cli: s.Client(),
+// 		URL: s.URL,
+// 	}
+// 	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014RFf87AsS0&filename=nrdiag-output.json&filesize=23456"
+// 	expectedResponse := jsonResponse{
+// 		URL: "https://mock-bucket.s3.amazonaws.com/staging/accounts/123456789/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+// 		Key: "accounts/123456789/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+// 	}
 
-	assert.Equal(t, http.StatusOK, res.StatusCode)
-	assert.Equal(t, expectedResponse, MyResult)
-}
+// 	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-func thisRouter(thisRequest func(w http.ResponseWriter, r *http.Request)) *mux.Router {
-	r := mux.NewRouter().StrictSlash(true)
-	r.Path("/attachments/upload_url").
-		Queries("attachment_key", "{attachment_key:[a-zA-Z0-9]{32}|[a-zA-Z0-9]{40}}", "filename", "{filename:nrdiag-output.json|nrdiag-output.zip}", "filesize", "{filesize:[0-9]+}").
-		HandlerFunc(thisRequest).
-		Name("/attachments/upload_url")
+// 	res, err := thisClient.cli.Do(req)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-	return r
-}
+// 	buf := new(bytes.Buffer)
+// 	_, err = buf.ReadFrom(res.Body)
+// 	if err != nil {
+// 		panic(err)
+// 	}
+// 	var MyResult jsonResponse
+// 	err = json.Unmarshal(buf.Bytes(), &MyResult)
+// 	if err != nil {
+// 		panic(err)
+// 	}
 
-func SuccessGetRequestAttachmentKey(w http.ResponseWriter, r *http.Request) {
-	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-attachment.json")
-	if err != nil {
-		panic(err)
-	}
+// 	assert.Equal(t, http.StatusOK, res.StatusCode)
+// 	assert.Equal(t, expectedResponse, MyResult)
+// }
 
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprint(w, string(rawResponse))
-}
-func SuccessGetRequestLicenseKey(w http.ResponseWriter, r *http.Request) {
-	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-license.json")
-	if err != nil {
-		panic(err)
-	}
+// func thisRouter(thisRequest func(w http.ResponseWriter, r *http.Request)) *mux.Router {
+// 	r := mux.NewRouter().StrictSlash(true)
+// 	r.Path("/attachments/upload_url").
+// 		Queries("attachment_key", "{attachment_key:[a-zA-Z0-9]{32}|[a-zA-Z0-9]{40}}", "filename", "{filename:nrdiag-output.json|nrdiag-output.zip}", "filesize", "{filesize:[0-9]+}").
+// 		HandlerFunc(thisRequest).
+// 		Name("/attachments/upload_url")
 
-	w.WriteHeader(http.StatusOK)
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprint(w, string(rawResponse))
-}
+// 	return r
+// }
 
-func FailureGetRequest(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusNotFound)
-	w.Header().Set("Content-Type", "application/json")
-}
+// func SuccessGetRequestAttachmentKey(w http.ResponseWriter, r *http.Request) {
+// 	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-attachment.json")
+// 	if err != nil {
+// 		panic(err)
+// 	}
+
+// 	w.WriteHeader(http.StatusOK)
+// 	w.Header().Set("Content-Type", "application/json")
+// 	fmt.Fprint(w, string(rawResponse))
+// }
+// func SuccessGetRequestLicenseKey(w http.ResponseWriter, r *http.Request) {
+// 	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-license.json")
+// 	if err != nil {
+// 		panic(err)
+// 	}
+
+// 	w.WriteHeader(http.StatusOK)
+// 	w.Header().Set("Content-Type", "application/json")
+// 	fmt.Fprint(w, string(rawResponse))
+// }
+
+// func FailureGetRequest(w http.ResponseWriter, r *http.Request) {
+// 	w.WriteHeader(http.StatusNotFound)
+// 	w.Header().Set("Content-Type", "application/json")
+// }

--- a/attach/attach_test.go
+++ b/attach/attach_test.go
@@ -2,30 +2,49 @@ package attach
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/gorilla/mux"
+	"github.com/newrelic/newrelic-diagnostics-cli/config"
 	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
 	"github.com/newrelic/newrelic-diagnostics-cli/mocks"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 var testServer *httptest.Server
 
+type MockGetReaderRet struct {
+	byts *bytes.Reader
+	err  error
+}
+type MockGetUrlsToReturnRet struct {
+	url *string
+	err error
+}
+type MockReturns struct {
+	getFileSize     int64
+	getReader       MockGetReaderRet
+	getWrapper      httpHelper.RequestWrapper
+	getUrlsToReturn MockGetUrlsToReturnRet
+}
+
 func setup() {
 	testServer = httptest.NewServer((http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if strings.Contains(r.URL.Path, "/success") {
-			fmt.Println("HERHEREHRERHERE")
 			w.WriteHeader(200)
 		}
 		if strings.Contains(r.URL.Path, "/error") {
-			fmt.Println("NONONONOONONO")
 
 			w.WriteHeader(500)
 		}
@@ -36,37 +55,77 @@ func teardown() {
 	testServer.Close()
 }
 
-// func TestUpload(t *testing.T) {
-// 	setup()
-// 	defer teardown()
-// 	type args struct {
-// 		identifyingKey string
-// 		timestamp      string
-// 		dependencies   IAttachDeps
-// 	}
-// 	tests := []struct {
-// 		name     string
-// 		args     args
-// 		endpoint string
-// 	}{
-// 		{
-// 			name: "Test successful Upload",
-// 			args: args{
-// 				identifyingKey: "TestKey",
-// 				timestamp:      "TimestampTest",
-// 				dependencies:   mocks.MAttachDeps{},
-// 			},
-// 			endpoint: "/success",
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			config.AttachmentEndpoint = testServer.URL + tt.endpoint
-// 			Upload(tt.args.identifyingKey, tt.args.timestamp, tt.args.dependencies)
-// 		})
-// 	}
-// }
+func Test_uploadFilesToAccount(t *testing.T) {
+	setup()
+	defer teardown()
+	type args struct {
+		filesToUpload []UploadFiles
+		attachmentKey string
+	}
+	jsonfile := UploadFiles{
+		Path:        "/",
+		Filename:    "file1.json",
+		NewFilename: "file1-timestamp.json",
+		Filesize:    4,
+		URL:         "",
+		Key:         "testKey",
+	}
 
+	wantedUrl := "https://newrelic.com"
+	tests := []struct {
+		name        string
+		args        args
+		want        []string
+		wantErr     bool
+		mockReturns MockReturns
+	}{
+		{
+			name: "Test successful uploadFilesToAccount",
+			args: args{
+				filesToUpload: []UploadFiles{jsonfile},
+				attachmentKey: "testKey",
+			},
+			wantErr: false,
+			want:    []string{wantedUrl},
+			mockReturns: MockReturns{
+				getFileSize: 4,
+				getReader: MockGetReaderRet{
+					byts: bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					err:  nil,
+				},
+				getWrapper: httpHelper.RequestWrapper{
+					Method:         "POST",
+					URL:            testServer.URL + "/success",
+					Payload:        bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					Length:         4,
+					TimeoutSeconds: awsUploadTimeoutSeconds,
+					Headers:        map[string]string{"Attachment-Key": "123563454"},
+				},
+				getUrlsToReturn: MockGetUrlsToReturnRet{
+					url: &wantedUrl,
+					err: nil,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockAttachDeps := new(mocks.MAttachDeps)
+			mockAttachDeps.On("GetFileSize", mock.Anything).Return(tt.mockReturns.getFileSize)
+			mockAttachDeps.On("GetReader", mock.Anything).Return(tt.mockReturns.getReader.byts, tt.mockReturns.getReader.err)
+			mockAttachDeps.On("GetWrapper", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.mockReturns.getWrapper)
+			mockAttachDeps.On("GetUrlsToReturn", mock.Anything).Return(tt.mockReturns.getUrlsToReturn.url, tt.mockReturns.getUrlsToReturn.err)
+			got, err := uploadFilesToAccount(tt.args.filesToUpload, tt.args.attachmentKey, mockAttachDeps)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("uploadFilesToAccount() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("uploadFilesToAccount() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 func Test_uploadFile(t *testing.T) {
 	setup()
 	defer teardown()
@@ -80,20 +139,6 @@ func Test_uploadFile(t *testing.T) {
 		Key:         "testKey",
 	}
 	wantedUrl := "https://newrelic.com"
-	type MockGetReaderRet struct {
-		byts *bytes.Reader
-		err  error
-	}
-	type MockGetUrlsToReturnRet struct {
-		url *string
-		err error
-	}
-	type MockReturns struct {
-		getFileSize     int64
-		getReader       MockGetReaderRet
-		getWrapper      httpHelper.RequestWrapper
-		getUrlsToReturn MockGetUrlsToReturnRet
-	}
 
 	type args struct {
 		filesToUpload UploadFiles
@@ -239,355 +284,303 @@ func Test_uploadFile(t *testing.T) {
 	}
 }
 
-// func TestAttachDeps_getAttachmentsEndpoint(t *testing.T) {
-// 	tests := []struct {
-// 		name                    string
-// 		attachmentEndpoint      string
-// 		flagsAttachmentEndpoint string
-// 		want                    string
-// 	}{
-// 		{
-// 			name:                    "Test GetAttachmentEndpoint none set",
-// 			attachmentEndpoint:      "",
-// 			flagsAttachmentEndpoint: "",
-// 			want:                    "http://localhost:3000/attachments",
-// 		},
-// 		{
-// 			name:                    "Test GetAttachmentEndpoint config.Flags.AttachmentEndpoint set",
-// 			attachmentEndpoint:      "",
-// 			flagsAttachmentEndpoint: "http://diag.datanerd.us/attachments",
-// 			want:                    "http://diag.datanerd.us/attachments",
-// 		},
-// 		{
-// 			name:                    "Test GetAttachmentEndpoint config.AttachmentEndpoint set",
-// 			attachmentEndpoint:      "http://diag.datanerd.us/attachments",
-// 			flagsAttachmentEndpoint: "",
-// 			want:                    "http://diag.datanerd.us/attachments",
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			config.Flags.AttachmentEndpoint = tt.flagsAttachmentEndpoint
-// 			config.AttachmentEndpoint = tt.attachmentEndpoint
-// 			if got := getAttachmentsEndpoint(); got != tt.want {
-// 				t.Errorf("AttachDeps.GetAttachmentsEndpoint() = %v, want %v", got, tt.want)
-// 			}
-// 		})
-// 	}
-// }
+func TestAttachDeps_getAttachmentsEndpoint(t *testing.T) {
+	tests := []struct {
+		name                    string
+		attachmentEndpoint      string
+		flagsAttachmentEndpoint string
+		want                    string
+	}{
+		{
+			name:                    "Test GetAttachmentEndpoint none set",
+			attachmentEndpoint:      "",
+			flagsAttachmentEndpoint: "",
+			want:                    "http://localhost:3000/attachments",
+		},
+		{
+			name:                    "Test GetAttachmentEndpoint config.Flags.AttachmentEndpoint set",
+			attachmentEndpoint:      "",
+			flagsAttachmentEndpoint: "http://diag.datanerd.us/attachments",
+			want:                    "http://diag.datanerd.us/attachments",
+		},
+		{
+			name:                    "Test GetAttachmentEndpoint config.AttachmentEndpoint set",
+			attachmentEndpoint:      "http://diag.datanerd.us/attachments",
+			flagsAttachmentEndpoint: "",
+			want:                    "http://diag.datanerd.us/attachments",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Flags.AttachmentEndpoint = tt.flagsAttachmentEndpoint
+			config.AttachmentEndpoint = tt.attachmentEndpoint
+			if got := getAttachmentsEndpoint(); got != tt.want {
+				t.Errorf("AttachDeps.GetAttachmentsEndpoint() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
-// // func TestAttachDeps_GetWrapper(t *testing.T) {
-// // 	type args struct {
-// // 		file          *bytes.Reader
-// // 		fileSize      int64
-// // 		filename      string
-// // 		attachmentKey string
-// // 	}
-// // 	mockAttachDeps := mocks.MAttachDeps{}
-// // 	mockFile, _ := mockAttachDeps.GetReader("")
-// // 	tests := []struct {
-// // 		name string
-// // 		args args
-// // 		want httpHelper.RequestWrapper
-// // 	}{
-// // 		{
-// // 			name: "Test GetWrapper",
-// // 			args: args{
-// // 				file:          mockFile,
-// // 				fileSize:      mockFile.Size(),
-// // 				filename:      "mockFile",
-// // 				attachmentKey: "testKey",
-// // 			},
-// // 			want: httpHelper.RequestWrapper{
-// // 				Method:         "POST",
-// // 				URL:            "http://localhost:3000/attachments/upload_s3?filename=mockFile",
-// // 				Headers:        map[string]string{"Attachment-Key": "testKey"},
-// // 				Payload:        mockFile,
-// // 				Length:         mockFile.Size(),
-// // 				TimeoutSeconds: 7200,
-// // 				BypassProxy:    false,
-// // 			},
-// // 		},
-// // 	}
-// // 	for _, tt := range tests {
-// // 		t.Run(tt.name, func(t *testing.T) {
-// // 			config.Flags.AttachmentEndpoint = ""
-// // 			config.AttachmentEndpoint = ""
-// // 			if got := GetWrapper(tt.args.file, tt.args.fileSize, tt.args.filename, tt.args.attachmentKey); !reflect.DeepEqual(got, tt.want) {
-// // 				t.Errorf("AttachDeps.GetWrapper() = %v, want %v", got, tt.want)
-// // 			}
-// // 		})
-// // 	}
-// // }
+func TestAttachDeps_makeRequest(t *testing.T) {
+	setup()
+	defer teardown()
+	type args struct {
+		wrapper httpHelper.RequestWrapper
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantStatusCode int
+	}{
+		{
+			name: "Test MakeRequest success",
+			args: args{
+				wrapper: httpHelper.RequestWrapper{
+					Method:         "POST",
+					URL:            testServer.URL + "/success",
+					Headers:        map[string]string{"Attachment-Key": "testKey"},
+					Payload:        bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					Length:         4,
+					TimeoutSeconds: 7200,
+					BypassProxy:    false,
+				},
+			},
+			wantStatusCode: 200,
+		},
+		{
+			name: "Test MakeRequest fail",
+			args: args{
+				wrapper: httpHelper.RequestWrapper{
+					Method:         "POST",
+					URL:            testServer.URL + "/error",
+					Headers:        map[string]string{"Attachment-Key": "testKey"},
+					Payload:        bytes.NewReader([]byte{'m', 'o', 'c', 'k'}),
+					Length:         4,
+					TimeoutSeconds: 7200,
+					BypassProxy:    false,
+				},
+			},
+			wantStatusCode: 500,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := makeRequest(tt.args.wrapper)
 
-// func TestAttachDeps_makeRequest(t *testing.T) {
-// 	setup()
-// 	defer teardown()
-// 	mockAttachDeps := mocks.MAttachDeps{}
-// 	mockFile, _ := mockAttachDeps.GetReader("")
-// 	type args struct {
-// 		wrapper httpHelper.RequestWrapper
-// 	}
-// 	tests := []struct {
-// 		name           string
-// 		args           args
-// 		wantStatusCode int
-// 		wantErr        bool
-// 	}{
-// 		{
-// 			name: "Test MakeRequest success",
-// 			args: args{
-// 				wrapper: httpHelper.RequestWrapper{
-// 					Method:         "POST",
-// 					URL:            testServer.URL + "/success",
-// 					Headers:        map[string]string{"Attachment-Key": "testKey"},
-// 					Payload:        mockFile,
-// 					Length:         mockFile.Size(),
-// 					TimeoutSeconds: 7200,
-// 					BypassProxy:    false,
-// 				},
-// 			},
-// 			wantStatusCode: 200,
-// 			wantErr:        false,
-// 		},
-// 		{
-// 			name: "Test MakeRequest fail",
-// 			args: args{
-// 				wrapper: httpHelper.RequestWrapper{
-// 					Method:         "POST",
-// 					URL:            testServer.URL + "/error",
-// 					Headers:        map[string]string{"Attachment-Key": "testKey"},
-// 					Payload:        mockFile,
-// 					Length:         mockFile.Size(),
-// 					TimeoutSeconds: 7200,
-// 					BypassProxy:    false,
-// 				},
-// 			},
-// 			wantStatusCode: 500,
-// 			wantErr:        true,
-// 		},
-// 	}
-// 	for _, tt := range tests {
-// 		t.Run(tt.name, func(t *testing.T) {
-// 			got, err := makeRequest(tt.args.wrapper)
-// 			if (err != nil) != tt.wantErr {
-// 				t.Errorf("AttachDeps.MakeRequest() error = %v, wantErr %v", err, tt.wantErr)
-// 				return
-// 			}
-// 			if got != nil {
-// 				if !reflect.DeepEqual(got.StatusCode, tt.wantStatusCode) {
-// 					t.Errorf("AttachDeps.MakeRequest() = %v, want %v", got, tt.wantStatusCode)
-// 					return
-// 				}
-// 			}
-// 		})
-// 	}
-// }
+			if got != nil {
+				if !reflect.DeepEqual(got.StatusCode, tt.wantStatusCode) {
+					t.Errorf("AttachDeps.MakeRequest() = %v, want %v", got, tt.wantStatusCode)
+					return
+				}
+			}
+		})
+	}
+}
 
 // // Legacy tests below
 
-// type Client struct {
-// 	cli *http.Client
-// 	URL string
-// }
+type Client struct {
+	cli *http.Client
+	URL string
+}
 
-// var _ = Describe("GetAttachmentEndpoints", func() {
-// 	var (
-// 		expectedResult string
-// 	)
-// 	Context("With no attachmentEndpointsSet", func() {
-// 		BeforeEach(func() {
-// 			config.Flags.AttachmentEndpoint = ""
-// 			config.AttachmentEndpoint = ""
-// 			expectedResult = "http://localhost:3000/attachments"
-// 		})
-// 		It("Should return default attachment endpoint (localhost)", func() {
-// 			result := getAttachmentsEndpoint()
-// 			Expect(result).To(Equal(expectedResult))
-// 		})
-// 	})
-// 	Context("With flag attachment endpoints set", func() {
-// 		BeforeEach(func() {
-// 			config.Flags.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
-// 			config.AttachmentEndpoint = ""
-// 			expectedResult = "http://diag.datanerd.us/attachments"
-// 		})
-// 		It("Should return flag attachment endpoint", func() {
-// 			result := getAttachmentsEndpoint()
-// 			Expect(result).To(Equal(expectedResult))
-// 		})
-// 	})
-// 	Context("With attachment endpoint set", func() {
-// 		BeforeEach(func() {
-// 			config.Flags.AttachmentEndpoint = ""
-// 			config.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
-// 			expectedResult = "http://diag.datanerd.us/attachments"
-// 		})
-// 		It("Should return attachment endpoint", func() {
-// 			result := getAttachmentsEndpoint()
-// 			Expect(result).To(Equal(expectedResult))
-// 		})
-// 	})
+var _ = Describe("GetAttachmentEndpoints", func() {
+	var (
+		expectedResult string
+	)
+	Context("With no attachmentEndpointsSet", func() {
+		BeforeEach(func() {
+			config.Flags.AttachmentEndpoint = ""
+			config.AttachmentEndpoint = ""
+			expectedResult = "http://localhost:3000/attachments"
+		})
+		It("Should return default attachment endpoint (localhost)", func() {
+			result := getAttachmentsEndpoint()
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
+	Context("With flag attachment endpoints set", func() {
+		BeforeEach(func() {
+			config.Flags.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
+			config.AttachmentEndpoint = ""
+			expectedResult = "http://diag.datanerd.us/attachments"
+		})
+		It("Should return flag attachment endpoint", func() {
+			result := getAttachmentsEndpoint()
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
+	Context("With attachment endpoint set", func() {
+		BeforeEach(func() {
+			config.Flags.AttachmentEndpoint = ""
+			config.AttachmentEndpoint = "http://diag.datanerd.us/attachments"
+			expectedResult = "http://diag.datanerd.us/attachments"
+		})
+		It("Should return attachment endpoint", func() {
+			result := getAttachmentsEndpoint()
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
 
-// })
+})
 
-// var _ = Describe("buildGetRequestURL", func() {
-// 	var (
-// 		expectedResult string
-// 	)
-// 	Context("with filename, attachmentKey, and filesize set", func() {
-// 		BeforeEach(func() {
-// 			config.Flags.AttachmentEndpoint = ""
-// 			config.AttachmentEndpoint = ""
-// 			expectedResult = "http://localhost:3000/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t56789014&filename=nrdiag-output.json&filesize=23647"
-// 		})
-// 		It("Should return default attachment endpoint (localhost)", func() {
-// 			result := buildGetRequestURL("nrdiag-output.json", "1Q3OS5O1ffsd2345678901t56789014", 23647)
-// 			Expect(result).To(Equal(expectedResult))
-// 		})
-// 	})
+var _ = Describe("buildGetRequestURL", func() {
+	var (
+		expectedResult string
+	)
+	Context("with filename, attachmentKey, and filesize set", func() {
+		BeforeEach(func() {
+			config.Flags.AttachmentEndpoint = ""
+			config.AttachmentEndpoint = ""
+			expectedResult = "http://localhost:3000/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t56789014&filename=nrdiag-output.json&filesize=23647"
+		})
+		It("Should return default attachment endpoint (localhost)", func() {
+			result := buildGetRequestURL("nrdiag-output.json", "1Q3OS5O1ffsd2345678901t56789014", 23647)
+			Expect(result).To(Equal(expectedResult))
+		})
+	})
 
-// })
+})
 
-// func TestGoodAttachmentUploadURL(t *testing.T) {
-// 	r := thisRouter(SuccessGetRequestAttachmentKey)
+func TestGoodAttachmentUploadURL(t *testing.T) {
+	r := thisRouter(SuccessGetRequestAttachmentKey)
 
-// 	s := httptest.NewServer(r)
-// 	defer s.Close()
+	s := httptest.NewServer(r)
+	defer s.Close()
 
-// 	thisClient := &Client{
-// 		cli: s.Client(),
-// 		URL: s.URL,
-// 	}
-// 	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014R&filename=nrdiag-output.zip&filesize=23456"
-// 	expectedResponse := jsonResponse{
-// 		URL: "https://mock-bucket.s3.amazonaws.com/staging/tickets/543210/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-// 		Key: "tickets/543210/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-// 	}
+	thisClient := &Client{
+		cli: s.Client(),
+		URL: s.URL,
+	}
+	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014R&filename=nrdiag-output.zip&filesize=23456"
+	expectedResponse := jsonResponse{
+		URL: "https://mock-bucket.s3.amazonaws.com/staging/tickets/543210/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+		Key: "tickets/543210/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+	}
 
-// 	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
+	if err != nil {
+		panic(err)
+	}
 
-// 	res, err := thisClient.cli.Do(req)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	res, err := thisClient.cli.Do(req)
+	if err != nil {
+		panic(err)
+	}
 
-// 	buf := new(bytes.Buffer)
-// 	_, err = buf.ReadFrom(res.Body)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	var MyResult jsonResponse
-// 	err = json.Unmarshal(buf.Bytes(), &MyResult)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	var MyResult jsonResponse
+	err = json.Unmarshal(buf.Bytes(), &MyResult)
+	if err != nil {
+		panic(err)
+	}
 
-// 	assert.Equal(t, http.StatusOK, res.StatusCode)
-// 	assert.Equal(t, expectedResponse, MyResult)
-// }
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, expectedResponse, MyResult)
+}
 
-// func TestBadAttachmentUploadURL(t *testing.T) {
-// 	r := thisRouter(FailureGetRequest)
+func TestBadAttachmentUploadURL(t *testing.T) {
+	r := thisRouter(FailureGetRequest)
 
-// 	s := httptest.NewServer(r)
-// 	defer s.Close()
+	s := httptest.NewServer(r)
+	defer s.Close()
 
-// 	thisClient := &Client{
-// 		cli: s.Client(),
-// 		URL: s.URL,
-// 	}
-// 	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=badattachmentkey&filename=nrdiag-output.json&filesize=34256"
+	thisClient := &Client{
+		cli: s.Client(),
+		URL: s.URL,
+	}
+	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=badattachmentkey&filename=nrdiag-output.json&filesize=34256"
 
-// 	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
+	if err != nil {
+		panic(err)
+	}
 
-// 	res, err := thisClient.cli.Do(req)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	res, err := thisClient.cli.Do(req)
+	if err != nil {
+		panic(err)
+	}
 
-// 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
-// }
+	assert.Equal(t, http.StatusNotFound, res.StatusCode)
+}
 
-// func TestGoodLicenseUploadURL(t *testing.T) {
-// 	r := thisRouter(SuccessGetRequestLicenseKey)
+func TestGoodLicenseUploadURL(t *testing.T) {
+	r := thisRouter(SuccessGetRequestLicenseKey)
 
-// 	s := httptest.NewServer(r)
-// 	defer s.Close()
+	s := httptest.NewServer(r)
+	defer s.Close()
 
-// 	thisClient := &Client{
-// 		cli: s.Client(),
-// 		URL: s.URL,
-// 	}
-// 	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014RFf87AsS0&filename=nrdiag-output.json&filesize=23456"
-// 	expectedResponse := jsonResponse{
-// 		URL: "https://mock-bucket.s3.amazonaws.com/staging/accounts/123456789/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-// 		Key: "accounts/123456789/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
-// 	}
+	thisClient := &Client{
+		cli: s.Client(),
+		URL: s.URL,
+	}
+	testAPIEndpoint := thisClient.URL + "/attachments/upload_url?attachment_key=1Q3OS5O1ffsd2345678901t5F789014RFf87AsS0&filename=nrdiag-output.json&filesize=23456"
+	expectedResponse := jsonResponse{
+		URL: "https://mock-bucket.s3.amazonaws.com/staging/accounts/123456789/attachments/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+		Key: "accounts/123456789/12345678-abcd-9876-fedc-abcdefabcdef/nrdiag-output-2021-04-29T05:15:00Z.json",
+	}
 
-// 	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	req, err := http.NewRequest("GET", testAPIEndpoint, nil)
+	if err != nil {
+		panic(err)
+	}
 
-// 	res, err := thisClient.cli.Do(req)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	res, err := thisClient.cli.Do(req)
+	if err != nil {
+		panic(err)
+	}
 
-// 	buf := new(bytes.Buffer)
-// 	_, err = buf.ReadFrom(res.Body)
-// 	if err != nil {
-// 		panic(err)
-// 	}
-// 	var MyResult jsonResponse
-// 	err = json.Unmarshal(buf.Bytes(), &MyResult)
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	buf := new(bytes.Buffer)
+	_, err = buf.ReadFrom(res.Body)
+	if err != nil {
+		panic(err)
+	}
+	var MyResult jsonResponse
+	err = json.Unmarshal(buf.Bytes(), &MyResult)
+	if err != nil {
+		panic(err)
+	}
 
-// 	assert.Equal(t, http.StatusOK, res.StatusCode)
-// 	assert.Equal(t, expectedResponse, MyResult)
-// }
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+	assert.Equal(t, expectedResponse, MyResult)
+}
 
-// func thisRouter(thisRequest func(w http.ResponseWriter, r *http.Request)) *mux.Router {
-// 	r := mux.NewRouter().StrictSlash(true)
-// 	r.Path("/attachments/upload_url").
-// 		Queries("attachment_key", "{attachment_key:[a-zA-Z0-9]{32}|[a-zA-Z0-9]{40}}", "filename", "{filename:nrdiag-output.json|nrdiag-output.zip}", "filesize", "{filesize:[0-9]+}").
-// 		HandlerFunc(thisRequest).
-// 		Name("/attachments/upload_url")
+func thisRouter(thisRequest func(w http.ResponseWriter, r *http.Request)) *mux.Router {
+	r := mux.NewRouter().StrictSlash(true)
+	r.Path("/attachments/upload_url").
+		Queries("attachment_key", "{attachment_key:[a-zA-Z0-9]{32}|[a-zA-Z0-9]{40}}", "filename", "{filename:nrdiag-output.json|nrdiag-output.zip}", "filesize", "{filesize:[0-9]+}").
+		HandlerFunc(thisRequest).
+		Name("/attachments/upload_url")
 
-// 	return r
-// }
+	return r
+}
 
-// func SuccessGetRequestAttachmentKey(w http.ResponseWriter, r *http.Request) {
-// 	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-attachment.json")
-// 	if err != nil {
-// 		panic(err)
-// 	}
+func SuccessGetRequestAttachmentKey(w http.ResponseWriter, r *http.Request) {
+	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-attachment.json")
+	if err != nil {
+		panic(err)
+	}
 
-// 	w.WriteHeader(http.StatusOK)
-// 	w.Header().Set("Content-Type", "application/json")
-// 	fmt.Fprint(w, string(rawResponse))
-// }
-// func SuccessGetRequestLicenseKey(w http.ResponseWriter, r *http.Request) {
-// 	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-license.json")
-// 	if err != nil {
-// 		panic(err)
-// 	}
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, string(rawResponse))
+}
+func SuccessGetRequestLicenseKey(w http.ResponseWriter, r *http.Request) {
+	rawResponse, err := ioutil.ReadFile("../mocks/hdash-response-good-license.json")
+	if err != nil {
+		panic(err)
+	}
 
-// 	w.WriteHeader(http.StatusOK)
-// 	w.Header().Set("Content-Type", "application/json")
-// 	fmt.Fprint(w, string(rawResponse))
-// }
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprint(w, string(rawResponse))
+}
 
-// func FailureGetRequest(w http.ResponseWriter, r *http.Request) {
-// 	w.WriteHeader(http.StatusNotFound)
-// 	w.Header().Set("Content-Type", "application/json")
-// }
+func FailureGetRequest(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusNotFound)
+	w.Header().Set("Content-Type", "application/json")
+}

--- a/go.mod
+++ b/go.mod
@@ -27,19 +27,16 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
-	github.com/jwalton/go-supportscolor v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
-	github.com/savioxavier/termlink v1.2.1 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
-	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -27,16 +27,19 @@ require (
 	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
+	github.com/jwalton/go-supportscolor v1.1.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.14 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b // indirect
 	github.com/rivo/uniseg v0.4.3 // indirect
+	github.com/savioxavier/termlink v1.2.1 // indirect
 	github.com/stretchr/objx v0.5.0 // indirect
 	github.com/tklauser/go-sysconf v0.3.11 // indirect
 	github.com/tklauser/numcpus v0.6.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.2 // indirect
+	golang.org/x/term v0.5.0 // indirect
 	golang.org/x/text v0.7.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jwalton/go-supportscolor v1.1.0 h1:HsXFJdMPjRUAx8cIW6g30hVSFYaxh9yRQwEWgkAR7lQ=
+github.com/jwalton/go-supportscolor v1.1.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c h1:VtwQ41oftZwlMnOEbMWQtSEUgU64U4s+GHk7hZK+jtY=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
@@ -52,6 +54,8 @@ github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:Om
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
+github.com/savioxavier/termlink v1.2.1 h1:O9ZQvk9BPQQK4JQeMB56ZfV8uam0Ts+f97mJme7+dq8=
+github.com/savioxavier/termlink v1.2.1/go.mod h1:WA7FTALNwN41NGnmQMIrnjAYTsEhIAZ4RuzgEiB0Jp8=
 github.com/shirou/gopsutil/v3 v3.22.11 h1:kxsPKS+Eeo+VnEQ2XCaGJepeP6KY53QoRTETx3+1ndM=
 github.com/shirou/gopsutil/v3 v3.22.11/go.mod h1:xl0EeL4vXJ+hQMAGN8B9VFpxukEMA0XdevQOe5MZ1oY=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
@@ -80,12 +84,17 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=
+golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=

--- a/go.sum
+++ b/go.sum
@@ -28,8 +28,6 @@ github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+
 github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/jwalton/go-supportscolor v1.1.0 h1:HsXFJdMPjRUAx8cIW6g30hVSFYaxh9yRQwEWgkAR7lQ=
-github.com/jwalton/go-supportscolor v1.1.0/go.mod h1:hFVUAZV2cWg+WFFC4v8pT2X/S2qUUBYMioBD9AINXGs=
 github.com/lufia/plan9stats v0.0.0-20211012122336-39d0f177ccd0/go.mod h1:zJYVVT2jmtg6P3p1VtQj7WsuWi/y4VnjVBn7F8KPB3I=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c h1:VtwQ41oftZwlMnOEbMWQtSEUgU64U4s+GHk7hZK+jtY=
 github.com/lufia/plan9stats v0.0.0-20220913051719-115f729f3c8c/go.mod h1:JKx41uQRwqlTZabZc+kILPrO/3jlKnQ2Z8b7YiVw5cE=
@@ -54,8 +52,6 @@ github.com/power-devops/perfstat v0.0.0-20221212215047-62379fc7944b/go.mod h1:Om
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.4.3 h1:utMvzDsuh3suAEnhH0RdHmoPbU648o6CvXxTx4SBMOw=
 github.com/rivo/uniseg v0.4.3/go.mod h1:FN3SvrM+Zdj16jyLfmOkMNblXMcoc8DfTHruCPUcx88=
-github.com/savioxavier/termlink v1.2.1 h1:O9ZQvk9BPQQK4JQeMB56ZfV8uam0Ts+f97mJme7+dq8=
-github.com/savioxavier/termlink v1.2.1/go.mod h1:WA7FTALNwN41NGnmQMIrnjAYTsEhIAZ4RuzgEiB0Jp8=
 github.com/shirou/gopsutil/v3 v3.22.11 h1:kxsPKS+Eeo+VnEQ2XCaGJepeP6KY53QoRTETx3+1ndM=
 github.com/shirou/gopsutil/v3 v3.22.11/go.mod h1:xl0EeL4vXJ+hQMAGN8B9VFpxukEMA0XdevQOe5MZ1oY=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
@@ -84,17 +80,12 @@ golang.org/x/sys v0.0.0-20190916202348-b4ddaad3f8a3/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201204225414-ed752295db88/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210220050731-9a76102bfb43/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.5.0 h1:MUK/U/4lj1t1oPg0HfuXDN/Z1wv31ZJ/YcPiGccS4DU=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/term v0.5.0 h1:n2a8QNdAb0sZNpU9R1ALUXBbY+w51fCQDN+7EdxNBsY=
-golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.6.0 h1:BOw41kyTf3PuCW1pVQf8+Cyg8pMlkYB1oo9iJ6D/lKM=

--- a/mocks/attach_mock.go
+++ b/mocks/attach_mock.go
@@ -12,7 +12,7 @@ type MAttachDeps struct {
 	mock.Mock
 }
 
-func (m MAttachDeps) GetFileSize(file string) int64 {
+func (m *MAttachDeps) GetFileSize(file string) int64 {
 	ret := m.Called(file)
 
 	var r0 int64
@@ -23,7 +23,7 @@ func (m MAttachDeps) GetFileSize(file string) int64 {
 	return r0
 }
 
-func (m MAttachDeps) GetReader(file string) (*bytes.Reader, error) {
+func (m *MAttachDeps) GetReader(file string) (*bytes.Reader, error) {
 	ret := m.Called(file)
 
 	var r0 *bytes.Reader
@@ -39,7 +39,7 @@ func (m MAttachDeps) GetReader(file string) (*bytes.Reader, error) {
 	return r0, r1
 }
 
-func (m MAttachDeps) GetWrapper(file *bytes.Reader, fileSize int64, filename string, attachmentKey string) httpHelper.RequestWrapper {
+func (m *MAttachDeps) GetWrapper(file *bytes.Reader, fileSize int64, filename string, attachmentKey string) httpHelper.RequestWrapper {
 	ret := m.Called(file, fileSize, filename, attachmentKey)
 
 	var r0 httpHelper.RequestWrapper
@@ -50,7 +50,7 @@ func (m MAttachDeps) GetWrapper(file *bytes.Reader, fileSize int64, filename str
 	return r0
 }
 
-func (m MAttachDeps) GetUrlsToReturn(res *http.Response) (*string, error) {
+func (m *MAttachDeps) GetUrlsToReturn(res *http.Response) (*string, error) {
 	ret := m.Called(res)
 
 	var r0 *string

--- a/mocks/attach_mock.go
+++ b/mocks/attach_mock.go
@@ -11,8 +11,8 @@ import (
 type MAttachDeps struct {
 	mock.Mock
 }
-type MockAttachResponse struct {
-	URL string
+type MUploadFile struct {
+	mock.Mock
 }
 
 func (m MAttachDeps) GetFileSize(file string) int64 {

--- a/mocks/attach_mock.go
+++ b/mocks/attach_mock.go
@@ -11,9 +11,6 @@ import (
 type MAttachDeps struct {
 	mock.Mock
 }
-type MUploadFile struct {
-	mock.Mock
-}
 
 func (m MAttachDeps) GetFileSize(file string) int64 {
 	ret := m.Called(file)

--- a/mocks/attach_mock.go
+++ b/mocks/attach_mock.go
@@ -1,14 +1,70 @@
 package mocks
 
-import "bytes"
+import (
+	"bytes"
+	"net/http"
 
-type MAttachDeps struct{}
+	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
+	"github.com/stretchr/testify/mock"
+)
+
+type MAttachDeps struct {
+	mock.Mock
+}
+type MockAttachResponse struct {
+	URL string
+}
 
 func (m MAttachDeps) GetFileSize(file string) int64 {
-	var ret int64 = 4
-	return ret
+	ret := m.Called(file)
+
+	var r0 int64
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
 }
 
 func (m MAttachDeps) GetReader(file string) (*bytes.Reader, error) {
-	return bytes.NewReader([]byte{'m', 'o', 'c', 'k'}), nil
+	ret := m.Called(file)
+
+	var r0 *bytes.Reader
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*bytes.Reader)
+	}
+
+	var r1 error
+	if ret.Get(1) != nil {
+		r1 = ret.Get(1).(error)
+	}
+
+	return r0, r1
+}
+
+func (m MAttachDeps) GetWrapper(file *bytes.Reader, fileSize int64, filename string, attachmentKey string) httpHelper.RequestWrapper {
+	ret := m.Called(file, fileSize, filename, attachmentKey)
+
+	var r0 httpHelper.RequestWrapper
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(httpHelper.RequestWrapper)
+	}
+
+	return r0
+}
+
+func (m MAttachDeps) GetUrlsToReturn(res *http.Response) (*string, error) {
+	ret := m.Called(res)
+
+	var r0 *string
+	if ret.Get(0) != nil {
+		r0 = ret.Get(0).(*string)
+	}
+
+	var r1 error
+	if ret.Get(1) != nil {
+		r1 = ret.Get(1).(error)
+	}
+
+	return r0, r1
 }


### PR DESCRIPTION
# Issue
There is no permalink to the Diag CLI Output in New Relic's UI
# Goals
To show where a customer can view the output of the Diag CLI runs
# Implementation Details
Return URL based on run conditions
# How to Test
go test ./...