### PR TITLE
feat: Release platform specific archives to download.newrelic.com

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 
+TEMPNAME=newrelic-diagnostics-cli
 EXENAME=nrdiag
 
 mkdir -p bin/mac
@@ -42,33 +43,29 @@ echo "running GOOS=windows go get -t ./..."
 $(GOOS=windows go get -t ./...)
 
 echo "Building Mac x64 $EXENAME"
-GOOS=darwin GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/mac/${EXENAME}_x64")
+GOOS=darwin GOARCH=amd64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+$(mv "$TEMPNAME" "bin/mac/${EXENAME}_x64")
 
 echo "Building Mac arm64 $EXENAME"
-GOOS=darwin GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/mac/${EXENAME}_arm64")
-
-echo "Building Linux 386"
-GOOS=linux GOARCH=386 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/linux/$EXENAME")
+GOOS=darwin GOARCH=amd64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+$(mv "$TEMPNAME" "bin/mac/${EXENAME}_arm64")
 
 echo "Building Linux x64"
-GOOS=linux GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/linux/${EXENAME}_x64")
+GOOS=linux GOARCH=amd64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+$(mv "$TEMPNAME" "bin/linux/${EXENAME}_x64")
 
 echo "Building Linux arm64"
-GOOS=linux GOARCH=arm64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/linux/${EXENAME}_arm64")
+GOOS=linux GOARCH=arm64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+$(mv "$TEMPNAME" "bin/linux/${EXENAME}_arm64")
 
 echo "Building Windows 386"
-GOOS=windows GOARCH=386 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/win/$EXENAME.exe")
+GOOS=windows GOARCH=386 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+$(mv "$TEMPNAME" "bin/win/$EXENAME.exe")
 
 echo "Building Windows x64"
-GOOS=windows GOARCH=amd64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/win/${EXENAME}_x64.exe")
+GOOS=windows GOARCH=amd64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+$(mv "$TEMPNAME" "bin/win/${EXENAME}_x64.exe")
 
 echo "Building Windows arm64"
-GOOS=windows GOARCH=arm64 go build -o "$EXENAME" -ldflags "$LDFLAGS"
-$(mv "$EXENAME" "bin/win/${EXENAME}_arm64.exe")
+GOOS=windows GOARCH=arm64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+$(mv "$TEMPNAME" "bin/win/${EXENAME}_arm64.exe")

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -1,42 +1,131 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script runs with the following env values passed in and mounts the current working directory into the container:
-# docker run --rm -e S3_BUCKET  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e BUILD_NUMBER -v $PWD/production:/root/go/src/github.com/newrelic/newrelic-diagnostics-cli/sharedfolder nrdiag-build ./scripts/upload.sh
-# To check files from command line: AWS_ACCESS_KEY_ID=abc AWS_SECRET_ACCESS_KEY=123 aws s3 ls s3://bucketname/nrdiag/
+#    $ docker run --rm -e S3_BUCKET -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e BUILD_NUMBER \
+#      -v $PWD/production:/root/go/src/github.com/newrelic/newrelic-diagnostics-cli/sharedfolder nrdiag-build ./scripts/upload.sh
+# To check files from command line:
+#    $ AWS_ACCESS_KEY_ID=abc AWS_SECRET_ACCESS_KEY=123 aws s3 ls s3://${S3_BUCKET}/nrdiag/
+
 set -e
-#make sure that input for BUILD_NUMBER=${{ github.event.release.name }} only contains digits otherwise we do not want to do a release
-if [[ $BUILD_NUMBER =~ ^[0-9]+$ ]]
-then
+
+# ------------------------- INIT
+BUILD_NUMBER_PATTERN="^[0-9]+$"
+VERSION=$(cat releaseVersion.txt | awk -F'currentReleaseVersion=' '{printf$2}')
+PREV_VERSION=$(cat releaseVersion.txt | awk -F'prevReleaseVersion=' '{printf$2}')
+ZIPFILENAME="nrdiag_${VERSION}.zip"
+SCRATCH_DIR="nrdiag_scratch_dir"
+BASE_DIR="nrdiag"
+
+# ------------------------- FUNCTIONS
+
+checkBuildNumber() {
+  if [[ ! ${BUILD_NUMBER} =~ ${BUILD_NUMBER_PATTERN} ]]; then
+    echo "The input passed for github.event.release.name was not a valid number. The release process did not run."
+    exit 1
+  fi
+}
+
+build() {
   echo "Running build script"
-  ./scripts/build.sh
+  sh ./scripts/build.sh
+  if [[ $? -ne 0 ]]; then
+    echo "Build failed, aborting release"
+    exit 1
+  fi
+  cp -r ./bin/* ${SCRATCH_DIR}/${BASE_DIR}
+}
 
-  VERSION=`cat releaseVersion.txt| awk -F'majorMinor=' '{printf$2}'`
-  ZIPFILENAME="nrdiag_${VERSION}.${BUILD_NUMBER}.zip"
+prepDirs() {
+  mkdir -p ${SCRATCH_DIR}/${BASE_DIR}
+}
 
+createVersionText() {
+  echo "${VERSION}" >>${SCRATCH_DIR}/${BASE_DIR}/version.txt
+}
+
+copyLicenseToZip() {
+  cp ./licenses/* ${SCRATCH_DIR}/${BASE_DIR}
+}
+
+createZip() {
   echo "Creating zipfile ${ZIPFILENAME}"
-  cd bin
-  cp ../licenses/* ./
-  echo "${VERSION}.${BUILD_NUMBER}" >> version.txt
-  mkdir ../nrdiag/
-  cp -r ./* ../nrdiag/
-  cd ../
-  zip -r $ZIPFILENAME nrdiag/
-  echo "Uploading to Download.Newrelic.com"
-  ln -s $ZIPFILENAME nrdiag_latest.zip
+  cd ./${SCRATCH_DIR}
+  zip -r ${ZIPFILENAME} ${BASE_DIR}
+  mv ${ZIPFILENAME} ./${BASE_DIR}
+  cd ..
+}
 
+cleanUpBeforeUpload() {
+  rm ${SCRATCH_DIR}/${BASE_DIR}/LICENSE*
+  rm ${SCRATCH_DIR}/${BASE_DIR}/README.txt
+  rm -rf ${SCRATCH_DIR}/${BASE_DIR}/linux
+  rm -rf ${SCRATCH_DIR}/${BASE_DIR}/mac
+  rm -rf ${SCRATCH_DIR}/${BASE_DIR}/win
+}
 
-  aws s3 cp ${ZIPFILENAME} s3://${S3_BUCKET}/nrdiag/
-  aws s3 cp nrdiag_latest.zip s3://${S3_BUCKET}/nrdiag/
-  aws s3 cp bin/version.txt s3://${S3_BUCKET}/nrdiag/
+createPlatformSpecificArchive() {
+  local plat=$1
+  local arch=$2
+  echo "Creating platform specific archive for $plat $arch"
 
-  echo "Finding oldest release on download.newrelic.com"
-  OLD_RELEASE=$(aws s3api list-objects-v2 --bucket ${S3_BUCKET} --prefix nrdiag/ --query 'sort_by(Contents[?Key && contains(Key, `.zip`) == `true` && contains(Key, `nrdiag`) == `true`], &LastModified)[:1].[Key]' --output text)
+  case ${plat} in
+  windows)
+    cd ./bin/win
+    if [[ "${arch}" == "x86" ]]; then
+      zip ../../${SCRATCH_DIR}/${BASE_DIR}/nrdiag_${VERSION}_Windows_${arch}.zip ./nrdiag.exe
+    else
+      zip ../../${SCRATCH_DIR}/${BASE_DIR}/nrdiag_${VERSION}_Windows_${arch}.zip ./nrdiag_${arch}.exe
+    fi
+    cd ../..
+    ;;
+  linux)
+    cd ./bin/linux
+    tar czvf ../../${SCRATCH_DIR}/${BASE_DIR}/nrdiag_${VERSION}_Linux_${arch}.tar.gz ./nrdiag_${arch}
+    cd ../..
+    ;;
 
-  echo "Oldest Release found: ${OLD_RELEASE}"
-  echo "Deleting ${OLD_RELEASE}"
-  aws s3 rm s3://${S3_BUCKET}/${OLD_RELEASE}
-  
-else
-  echo "The input passed for github.event.release.name was not a valid number. The release process did not run."
-fi
+  *)
+    echo "Unknown platform: ${plat}"
+    echo "Aborting release"
+    exit 1
+    ;;
+  esac
+}
 
+uploadToAws() {
+  echo "Uploading to download.newrelic.com"
+  cd ./${SCRATCH_DIR}/${BASE_DIR}
+  for file in *; do
+    aws s3 cp ${file} s3://${S3_BUCKET}/${BASE_DIR}/${file}
+  done
+  aws s3 cp s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_${VERSION}.zip s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_latest.zip
+  cd ../..
+}
+
+removeOldestFromAws() {
+  echo "Finding all files for oldest release on download.newrelic.com"
+  local aws_sort_query='sort_by(Contents[?Key && (contains(Key, `.zip`) == `true` || contains(Key, `.tar.gz`) == `true`) && contains(Key, `nrdiag`) == `true` && contains(Key, `latest`) == `false` && contains(Key, `'"${VERSION}"'`) == `false` && contains(Key, `'"${PREV_VERSION}"'`) == `false`], &LastModified)[].[Key]'
+  IFS=$'\n' read -r -d '' -a old_releases < <(aws s3api list-objects-v2 --bucket ${S3_BUCKET} --prefix nrdiag/ --query "${aws_sort_query}" --output text && printf '\0')
+  for rel in "${old_releases[@]}"; do
+    aws s3 rm s3://${S3_BUCKET}/${rel}
+  done
+}
+
+# ------------------------- MAIN
+
+checkBuildNumber
+prepDirs
+build
+createVersionText
+copyLicenseToZip
+createZip
+createPlatformSpecificArchive linux x64
+createPlatformSpecificArchive linux arm64
+createPlatformSpecificArchive windows x86
+createPlatformSpecificArchive windows x64
+createPlatformSpecificArchive windows arm64
+cleanUpBeforeUpload
+uploadToAws
+removeOldestFromAws
+
+exit 0


### PR DESCRIPTION
# Issue

We need platform specific archives to support a 1 line installation method

# Goals

To update the upload.sh script to create the needed archives

# Implementation Details

I updated the upload.sh script to create the needed archives. I also added logic to the code for deleting the old releases, it no longer uses the Last Modified date but rather just keeps the current version and previous version (as defined in the releaseVersion.txt file), and deletes anything else.

# How to Test

1. Make sure your local aws cli  is pointing at the [REDACTED]'s AWS account. There is a test bucket there. It currently has releases 2.3.3 and 2.3.4 there.
2. Update the releases in `releaseVersion.txt` to something like

```
majorMinor=2.3
buildNumber=5
currentReleaseVersion=2.3.5
prevReleaseVersion=2.3.4
```

3. Run

```
S3_BUCKET=[REDACTED] BUILD_NUMBER=5 ./scripts/upload.sh
```

4. Check the [REDACTED] bucket and make sure it has 2.3.5 and 2.3.4 releases, nrdiag_latest.zip, and version.txt only:

```
aws s3 ls s3://[REDACTED]/nrdiag/
```

5. Open each archive (they should be in ./nrdiag_scratch_dir/nrdiag/), and ensure the contents look right.