### PR TITLE
feat: Install script for linux

### DIFF
--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+
+# Install the New Relic Diagnostics CLI.
+# https://github.com/newrelic/newrelic-diagnostics-cli
+#
+# Dependencies: curl, cut, tar, gzip
+#
+# The binary location can be passed in via DESTDIR, otherwise it installs to pwd.
+#
+
+set -e
+
+# ------------------------- INIT
+
+UNAME=($(uname -ms))
+PLAT=${UNAME[0]}
+ARCH=${UNAME[1]}
+if [ -z "${BASE_URL}" ]; then
+    BASE_URL="https://download.newrelic.com"
+fi
+MANUAL_INSTALL_DOC="https://docs.newrelic.com/docs/new-relic-solutions/solve-common-issues/diagnostics-cli-nrdiag/run-diagnostics-cli-nrdiag/"
+DESTDIR="${DESTDIR:-${PWD}}"
+
+# ------------------------- FUNCTIONS
+
+checkOS() {
+    case ${PLAT} in
+    Linux) ;;
+    *)
+        echo "This operating system is not supported by this installation script. Please install the New Relic Diagnostics CLI manually."
+        echo "${MANUAL_INSTALL_DOC}"
+        exit 1
+        ;;
+    esac
+
+    case $ARCH in
+    arm64 | aarch64)
+        ARCH="arm64"
+        ;;
+    x86_64)
+        ARCH="x64"
+        ;;
+    *)
+        echo "This machine architecture is not supported. The supported architectures are x86_64 and arm64."
+        exit 1
+        ;;
+    esac
+}
+
+checkReqs() {
+    for x in cut tar gzip sudo; do
+        which $x >/dev/null || (
+            echo "Unable to continue.  Please install $x before proceeding."
+            exit 1
+        )
+    done
+}
+
+checkAndInstallCurl() {
+    local DISTRO=$(cat /etc/issue /etc/system-release /etc/redhat-release /etc/os-release 2>/dev/null | grep -m 1 -Eo "(Ubuntu|Amazon|CentOS|Debian|Red Hat|SUSE)" || true)
+
+    local IS_CURL_INSTALLED=$(which curl | wc -l)
+    if [ ${IS_CURL_INSTALLED} -eq 0 ]; then
+        echo "curl is required to install, please confirm Y/N to install (default Y): "
+        read -r CONFIRM_CURL
+        if [ "${CONFIRM_CURL}" == "Y" ] || [ "${CONFIRM_CURL}" == "y" ] || [ "${CONFIRM_CURL}" == "" ]; then
+            if [ "${DISTRO}" == "Ubuntu" ] || [ "${DISTRO}" == "Debian" ]; then
+                sudo apt-get update
+                sudo apt-get install curl -y
+            elif [ "${DISTRO}" == "Amazon" ] || [ "${DISTRO}" == "CentOS" ] || [ "${DISTRO}" == "Red Hat" ]; then
+                sudo yum install curl -y
+            elif [ "${DISTRO}" == "SUSE" ]; then
+                sudo zypper -n install curl
+            else
+                echo "Unable to continue. Please install curl manually before proceeding."
+                exit 1
+            fi
+        else
+            echo "Unable to continue without curl. Please install curl before proceeding."
+            exit 1
+        fi
+    fi
+}
+
+getLatestVersion() {
+    VERSION=$(curl -sL ${BASE_URL}/nrdiag/version.txt)
+}
+
+checkConnectivity() {
+    curl --connect-timeout 10 -IsL "${BASE_URL}" >/dev/null || (echo "Cannot connect to ${BASE_URL} to download the New Relic Diagnostics CLI. Check your firewall settings. If you are using a proxy, make sure you have set the HTTPS_PROXY environment variable." && exit 1)
+}
+
+setupDirectories() {
+    if [ ! -d "${DESTDIR}" ]; then
+        mkdir -m 755 -p "${DESTDIR}"
+    fi
+    SCRATCH=$(mktemp -d || mktemp -d -t 'tmp')
+    cd "${SCRATCH}"
+
+}
+
+downloadAndExtract() {
+    echo "Installing New Relic Diagnostics CLI v${VERSION}"
+    curl -sL --retry 3 "${BASE_URL}/nrdiag/nrdiag_${VERSION}_${PLAT}_${ARCH}.tar.gz" | tar -xz
+}
+
+moveToDestDir() {
+    if [ "$UID" != "0" ]; then
+        echo "Installing to ${DESTDIR} using sudo"
+        mv "nrdiag_${ARCH}" "${DESTDIR}/nrdiag"
+        chmod +x "${DESTDIR}/nrdiag"
+        sudo chown root:0 "${DESTDIR}/nrdiag"
+    else
+        echo "Installing to ${DESTDIR}"
+        mv "nrdiag_${ARCH}" "${DESTDIR}/nrdiag"
+        chmod +x "${DESTDIR}/nrdiag"
+        chown root:0 "${DESTDIR}/nrdiag"
+    fi
+}
+
+cleanup() {
+    rm -r "${SCRATCH}"
+}
+
+error() {
+    echo "An error occurred installing the tool."
+    echo "The contents of the directory ${SCRATCH} have been left in place to help to debug the issue."
+}
+
+# ------------------------- MAIN
+
+echo "Starting installation."
+trap error ERR
+checkOS
+checkReqs
+checkAndInstallCurl
+checkConnectivity
+getLatestVersion
+setupDirectories
+downloadAndExtract
+moveToDestDir
+cleanup
+exit 0

--- a/scripts/install/install.sh
+++ b/scripts/install/install.sh
@@ -33,7 +33,7 @@ checkOS() {
         ;;
     esac
 
-    case $ARCH in
+    case ${ARCH} in
     arm64 | aarch64)
         ARCH="arm64"
         ;;


### PR DESCRIPTION
# Issue

IHEDIAG-311

# Goals

Create an installation script for nrdiag on Linux to facilitate 1 line install and run

# Implementation Details

The script checks to make sure it's being run on Linux and either x64 or arm64. Linux x86 is no longer supported by nrdiag.

The script also checks for needed prereqs: cut, tar, gzip, sudo, curl

For curl, if it isn't installed, it will ask if the user wants to install it and try to install based on the distro.

By default it installs nrdiag to the pwd, but you can specify a specific directory with `DESTDIR`

The installation goes to a tmp dir then is moved to the final destination. The tmp dir is cleaned up unless there is an error, it's left intact if there's an error to assist with debugging.

The binary is just named `nrdiag` in the end, it removes the `_x64` or `_arm64`.

It only installs the latest version, version is not configurable.

# How to Test

1. Copy the install script to your test host
  * I used scp `scp -i "your-cert" ./scripts/install/install.sh your-host:/tmp`
2. Set the BASE_URL to the test location (ask me for this in slack)
  * `export BASE_URL="https://......com"`
3. Run it
  * `curl -Ls file:///tmp/install.sh | bash && sudo ./nrdiag`
  * feel free to add a task or suite to the command, ie: `curl -Ls file:///tmp/install.sh | bash && sudo ./nrdiag -s node`