### PR TITLE
feat: Fix upload error

### DIFF
--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -98,7 +98,7 @@ uploadToAws() {
   for file in *; do
     aws s3 cp ${file} s3://${S3_BUCKET}/${BASE_DIR}/${file}
   done
-  aws s3 cp s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_${VERSION}.zip s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_latest.zip
+  aws s3 cp s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_${VERSION}.zip s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_latest.zip --copy-props none
   cd ../..
 }
 


### PR DESCRIPTION
# Issue

```
 upload: ./nrdiag_2.4.1_Windows_x86.zip to s3://***/nrdiag/nrdiag_2.4.1_Windows_x86.zip
Completed 6 Bytes/6 Bytes (13 Bytes/s) with 1 file(s) remaining
upload: ./version.txt to s3://***/nrdiag/version.txt
copy failed: s3://***/nrdiag/nrdiag_2.4.1.zip to s3://***/nrdiag/nrdiag_latest.zip An error occurred (AccessDenied) when calling the GetObjectTagging operation: Access Denied
Error: Process completed with exit code 1.
```


# Goals

Releases run without errors

# Implementation Details

Per https://stackoverflow.com/questions/68824370/amazon-s3-cp-fails-with-accessdenied-when-calling-the-getobjecttagging-operati, I added `--copy-props none` to the command that failed.

# How to Test

It can be tested against the test bucket, I can send details in slack