### PR TITLE
feat: Rollback script

### DIFF
--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,26 +1,49 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Rollback to the previous version of the New Relic Diagnostics CLI.
+#
+
 set -e
 
-CURRENT=$(cat releaseVersion.txt | awk -F'currentReleaseVersion=' '{printf$2}')
-CURRENTZIP="nrdiag_${CURRENT}.zip"
+# ------------------------- INIT
+VERSION_TO_REMOVE=$(cat releaseVersion.txt | awk -F'currentReleaseVersion=' '{printf$2}')
+VERSION_TO_KEEP=$(cat releaseVersion.txt | awk -F'prevReleaseVersion=' '{printf$2}')
+BASE_DIR="nrdiag"
 
-PREV=$(cat releaseVersion.txt | awk -F'prevReleaseVersion=' '{printf$2}')
-PREVZIP="nrdiag_${PREV}.zip"
+# ------------------------- FUNCTIONS
+checkS3BucketIsSet() {
+    if [ -z "${S3_BUCKET}" ]; then
+        echo "The S3 bucket variable was not passed in, aborting."
+        exit 1
+    fi
+}
 
-echo "current aws version is:"
-aws --version
+findAndRemove() {
+    echo "Finding and removing all files for version ${VERSION_TO_REMOVE} on download.newrelic.com"
+    local aws_sort_query='sort_by(Contents[?Key && (contains(Key, `.zip`) == `true` || contains(Key, `.tar.gz`) == `true`) && contains(Key, `nrdiag`) == `true` && contains(Key, `latest`) == `false` && contains(Key, `'"${VERSION_TO_REMOVE}"'`) == `true`], &LastModified)[].[Key]'
+    IFS=$'\n' read -r -d '' -a files_to_remove < <(aws s3api list-objects-v2 --bucket "${S3_BUCKET}" --prefix "${BASE_DIR}"/ --query "${aws_sort_query}" --output text && printf '\0')
+    for rel in "${files_to_remove[@]}"; do
+        aws s3 rm s3://${S3_BUCKET}/${rel}
+    done
+}
 
-echo "deleting current release zip file ..."
-aws s3 rm s3://${S3_BUCKET}/nrdiag/${CURRENTZIP}
+fixVersionTxt() {
+    echo "Deleting version.txt"
+    aws s3 rm s3://${S3_BUCKET}/${BASE_DIR}/version.txt
+    echo "Creating a new version.txt inserting the previous version"
+    echo ${VERSION_TO_KEEP} >>version.txt
+    aws s3 cp version.txt s3://${S3_BUCKET}/${BASE_DIR}/version.txt
+    echo "Cleaning up local version.txt"
+    rm ./version.txt
+}
 
-echo "deleting version.txt ..."
-aws s3 rm s3://${S3_BUCKET}/nrdiag/version.txt
-echo "creating a new version.txt inserting the previous version ..."
-echo ${PREV} >> version.txt
-aws s3 cp version.txt s3://${S3_BUCKET}/nrdiag/version.txt
-echo "version is now:"
-aws s3 cp s3://nr-downloads-main/nrdiag/version.txt -
+recreateLatestZip() {
+    echo "Recreating nrdiag_latest.zip with version ${VERSION_TO_KEEP}"
+    aws s3 cp s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_${VERSION_TO_KEEP}.zip s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_latest.zip --copy-props none
+}
 
-echo "replacing nrdiag_latest.zip to be the previous one ..."
-#once ubuntu-latest image upgrades their aws version to version 2, we'll need to update this command to use "--copy-props metadata-directive" arguments to avoid calling GetObjectTagging permission when copying a  file from bucket to bucket:
-aws s3 cp s3://${S3_BUCKET}/nrdiag/${PREVZIP} s3://${S3_BUCKET}/nrdiag/nrdiag_latest.zip
+# ------------------------- MAIN
+checkS3BucketIsSet
+findAndRemove
+fixVersionTxt
+recreateLatestZip

--- a/scripts/upload.sh
+++ b/scripts/upload.sh
@@ -98,14 +98,14 @@ uploadToAws() {
   for file in *; do
     aws s3 cp ${file} s3://${S3_BUCKET}/${BASE_DIR}/${file}
   done
-  aws s3 cp s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_${VERSION}.zip s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_latest.zip
+  aws s3 cp s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_${VERSION}.zip s3://${S3_BUCKET}/${BASE_DIR}/nrdiag_latest.zip --copy-props none
   cd ../..
 }
 
 removeOldestFromAws() {
   echo "Finding all files for oldest release on download.newrelic.com"
   local aws_sort_query='sort_by(Contents[?Key && (contains(Key, `.zip`) == `true` || contains(Key, `.tar.gz`) == `true`) && contains(Key, `nrdiag`) == `true` && contains(Key, `latest`) == `false` && contains(Key, `'"${VERSION}"'`) == `false` && contains(Key, `'"${PREV_VERSION}"'`) == `false`], &LastModified)[].[Key]'
-  IFS=$'\n' read -r -d '' -a old_releases < <(aws s3api list-objects-v2 --bucket ${S3_BUCKET} --prefix nrdiag/ --query "${aws_sort_query}" --output text && printf '\0')
+  IFS=$'\n' read -r -d '' -a old_releases < <(aws s3api list-objects-v2 --bucket "${S3_BUCKET}" --prefix "${BASE_DIR}"/ --query "${aws_sort_query}" --output text && printf '\0')
   for rel in "${old_releases[@]}"; do
     aws s3 rm s3://${S3_BUCKET}/${rel}
   done


### PR DESCRIPTION
# Issue

We need a rollback script

Also this error on release:

```
 upload: ./nrdiag_2.4.1_Windows_x86.zip to s3://***/nrdiag/nrdiag_2.4.1_Windows_x86.zip
Completed 6 Bytes/6 Bytes (13 Bytes/s) with 1 file(s) remaining
upload: ./version.txt to s3://***/nrdiag/version.txt
copy failed: s3://***/nrdiag/nrdiag_2.4.1.zip to s3://***/nrdiag/nrdiag_latest.zip An error occurred (AccessDenied) when calling the GetObjectTagging operation: Access Denied
Error: Process completed with exit code 1.
```

# Goals

1. Be able to rollback

2. Releases run without errors

# Implementation Details

The rollback script has been updated to remove all relevant files for the current version then update the `nrdiag_latest.zip` file to be the previous version. Also updates the version.txt file.

For the error on release:

Per https://stackoverflow.com/questions/68824370/amazon-s3-cp-fails-with-accessdenied-when-calling-the-getobjecttagging-operati, I added `--copy-props none` to the command that failed.

# How to Test

Both can be tested against the test bucket, I can send details in slack