### PR TITLE
fix(infra): Infra/Env/ClockSkew

### DIFF
--- a/tasks/infra/env/clockSkew_test.go
+++ b/tasks/infra/env/clockSkew_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Infra/Env/ClockSkew", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
-					"Infra/Agent/Connect": tasks.Result{
+					"Infra/Agent/Connect": {
 						Status:  tasks.Success,
 						Payload: "Incorrect payload",
 					},
@@ -95,11 +95,9 @@ var _ = Describe("Infra/Env/ClockSkew", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 
-					"Infra/Agent/Connect": tasks.Result{
-						Status: tasks.Failure,
-						Payload: map[string]string{
-							"requestURLs": "",
-						},
+					"Infra/Agent/Connect": {
+						Status:  tasks.Failure,
+						Payload: []string{},
 					},
 				}
 				p.httpGetter = mockInvalidDateHeader
@@ -107,7 +105,25 @@ var _ = Describe("Infra/Env/ClockSkew", func() {
 
 			It("It should a return task.Error and a Summary", func() {
 				Expect(result.Status).To(Equal(tasks.Error))
-				Expect(result.Summary).To(Equal("Unable to determine New Relic collector time"))
+				Expect(result.Summary).To(Equal("Unable to determine New Relic collector URL from Infra/Agent/Connect task"))
+			})
+		})
+
+		Context("When upstream returns tasks.None result", func() {
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+
+					"Infra/Agent/Connect": {
+						Status: tasks.None,
+					},
+				}
+				p.httpGetter = mockInvalidDateHeader
+			})
+
+			It("It should a return task.Error and a Summary", func() {
+				Expect(result.Status).To(Equal(tasks.None))
+				Expect(result.Summary).To(Equal("Unable to retrieve urls from Infra/Agent/Connect. This task did not run"))
 			})
 		})
 
@@ -117,19 +133,17 @@ var _ = Describe("Infra/Env/ClockSkew", func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 
-					"Infra/Agent/Connect": tasks.Result{
+					"Infra/Agent/Connect": {
 						Status: tasks.Success,
-						Payload: map[string]string{
-							"requestURLs": "https://infra-api.newrelic.com",
+						Payload: []string{
+							"https://infra-api.newrelic.com",
 						},
 					},
 				}
 				p.httpGetter = mockValidDateHeader
-				hostTime, _ := time.Parse(time.RFC1123, "Wed, 26 Feb 2020 11:45:17 GMT")
-				p.checkForClockSkew = func(time.Time) (bool, int, time.Time) {
-					return true, 61, hostTime.In(time.UTC)
+				p.checkForClockSkew = func(time.Time, time.Time) (bool, int) {
+					return true, 61
 				}
-
 			})
 
 			Context("in windows environments", func() {
@@ -138,48 +152,59 @@ var _ = Describe("Infra/Env/ClockSkew", func() {
 				})
 
 				It("It should a return a failure Status and Summary", func() {
-					expectedSummary := "Detected clock skew of 61 seconds between host and New Relic collector. This could lead to chart irregularities:\n\tHost time:      2020-02-26 11:45:17 +0000 UTC\n\tCollector time: 2020-02-26 10:45:17 +0000 UTC\nYour host may be affected by clock skew. Please consider using NTP to keep your host clocks in sync."
+					expectedSummary := "Detected clock skew of 61 seconds between host and New Relic collector[.] This could lead to chart irregularities:\n\tHost time: .+\n\tCollector time: .+\nYour host may be affected by clock skew. Please consider using NTP to keep your host clocks in sync."
 					Expect(result.Status).To(Equal(tasks.Failure))
-					Expect(result.Summary).To(Equal(expectedSummary))
-					Expect(result.URL).To(Equal(troubleshootingURLwindows))
-				})
-			})
-
-			Context("in non-windows environments", func() {
-				BeforeEach(func() {
-					p.runtimeOS = "linux"
-				})
-
-				It("It should a return a failure Status and Summary", func() {
-					expectedSummary := "Detected clock skew of 61 seconds between host and New Relic collector. This could lead to chart irregularities:\n\tHost time:      2020-02-26 11:45:17 +0000 UTC\n\tCollector time: 2020-02-26 10:45:17 +0000 UTC\nYour host may be affected by clock skew. Please consider using NTP to keep your host clocks in sync."
-					Expect(result.Status).To(Equal(tasks.Failure))
-					Expect(result.Summary).To(Equal(expectedSummary))
-					Expect(result.URL).To(Equal(troubleshootingURLlinux))
+					Expect(result.Summary).To(MatchRegexp(expectedSummary))
 				})
 			})
 
 		})
+
 		Context("When clock is off by a couple of seconds but still in sync", func() {
 			BeforeEach(func() {
 				options = tasks.Options{}
 				upstream = map[string]tasks.Result{
 
-					"Infra/Agent/Connect": tasks.Result{
+					"Infra/Agent/Connect": {
 						Status: tasks.Success,
-						Payload: map[string]string{
-							"requestURLs": "https://infra-api.newrelic.com",
+						Payload: []string{
+							"https://infra-api.newrelic.com",
 						},
 					},
 				}
 				p.httpGetter = mockValidDateHeader
-				hostTime, _ := time.Parse(time.RFC1123, "Wed, 26 Feb 2020 10:45:19 GMT")
-				p.checkForClockSkew = func(time.Time) (bool, int, time.Time) {
-					return false, 2, hostTime
+				p.checkForClockSkew = func(time.Time, time.Time) (bool, int) {
+					return false, 2
 				}
 
 			})
 
-			It("It should a return a failure Status and Summary", func() {
+			It("It should a return a successful Status and Summary", func() {
+				expectedSummary := "System clock in sync with New Relic collector"
+				Expect(result.Status).To(Equal(tasks.Success))
+				Expect(result.Summary).To(Equal(expectedSummary))
+			})
+		})
+
+		Context("When infra-api is not in the collector URLs", func() {
+			BeforeEach(func() {
+				options = tasks.Options{}
+				upstream = map[string]tasks.Result{
+					"Infra/Agent/Connect": {
+						Status: tasks.Success,
+						Payload: []string{
+							"https://metric-api.newrelic.com",
+						},
+					},
+				}
+				p.httpGetter = mockValidDateHeader
+				p.checkForClockSkew = func(time.Time, time.Time) (bool, int) {
+					return false, 2
+				}
+
+			})
+
+			It("It should a return a successful Status and Summary", func() {
 				expectedSummary := "System clock in sync with New Relic collector"
 				Expect(result.Status).To(Equal(tasks.Success))
 				Expect(result.Summary).To(Equal(expectedSummary))
@@ -226,4 +251,47 @@ var _ = Describe("Infra/Env/ClockSkew", func() {
 
 		})
 	})
+
+	Describe("checkForClockSkew()", func() {
+		var (
+			isClockDiffRelevant bool
+			diffSeconds         int
+			hostTime            time.Time
+			serverTime          time.Time
+		)
+
+		JustBeforeEach(func() {
+			isClockDiffRelevant, diffSeconds = checkForClockSkew(serverTime, hostTime)
+		})
+
+		Context("checkForClockSkew successfully detects skew under 60 seconds", func() {
+			BeforeEach(func() {
+				hostTime, _ = time.Parse(time.RFC1123, "Wed, 24 May 2023 12:00:00 GMT")
+				serverTime, _ = time.Parse(time.RFC1123, "Wed, 24 May 2023 12:00:02 GMT")
+			})
+
+			It("should return false and 2", func() {
+				expectedIsClockDiffRelevant := false
+				expectedDiffSeconds := 2
+				Expect(isClockDiffRelevant).To(Equal(expectedIsClockDiffRelevant))
+				Expect(diffSeconds).To(Equal(expectedDiffSeconds))
+			})
+		})
+
+		Context("checkForClockSkew successfully detects skew over 60 seconds", func() {
+			BeforeEach(func() {
+				hostTime, _ = time.Parse(time.RFC1123, "Wed, 24 May 2023 12:00:00 GMT")
+				serverTime, _ = time.Parse(time.RFC1123, "Wed, 24 May 2023 12:01:01 GMT")
+			})
+
+			It("should return true and 61", func() {
+				expectedIsClockDiffRelevant := true
+				expectedDiffSeconds := 61
+				Expect(isClockDiffRelevant).To(Equal(expectedIsClockDiffRelevant))
+				Expect(diffSeconds).To(Equal(expectedDiffSeconds))
+			})
+		})
+
+	})
+
 })


### PR DESCRIPTION
# Issue

https://github.com/newrelic/newrelic-diagnostics-cli/issues/167

# Goals

Fix the bug in Infra/Env/ClockSkew 

# Implementation Details

The type assertion error was occurring due to a type change in the payload for Infra/Agent/Connect from map[string]string to []string. (https://github.com/newrelic/newrelic-diagnostics-cli/pull/139)

Refactored task to work with collector urls being a []string, also refactored to allow for more testing

# How to Test

```
go test github.com/newrelic/newrelic-diagnostics-cli/tasks/infra/env
```