### PR TITLE
fix: Diagnostics CLI Attach only when flags present

### DIFF
--- a/processTasks.go
+++ b/processTasks.go
@@ -211,12 +211,13 @@ func processUploads() {
 		return
 	}
 
-	question := "We've created nrdiag-output.zip and nrdiag-output.json\n" +
-		"Do you want to upload these to your New Relic account?"
-	if promptUser(question) {
-		checkAttachmentFlags(timestamp)
+	if config.Flags.APIKey != "" || config.Flags.AutoAttach {
+		question := "We've created nrdiag-output.zip and nrdiag-output.json\n" +
+			"Do you want to upload these to your New Relic account?"
+		if promptUser(question) {
+			checkAttachmentFlags(timestamp)
+		}
 	}
-
 }
 
 func checkAttachmentFlags(timestamp string) {


### PR DESCRIPTION
# Issue
https://newrelic.atlassian.net/jira/software/c/projects/IHEDIAG/boards/2062?modal=detail&selectedIssue=IHEDIAG-457
# Goals
Only prompt the user to attach when they have provided a flag that indicates they want to attach
# Implementation Details
Wrap the prompt in a check for the attachment flags
# How to Test
Smoke test with no attachment flags, `-a`, and `-api-key`