### PR TITLE
feat: Fix output for uploading

### DIFF
--- a/attach/attach.go
+++ b/attach/attach.go
@@ -69,7 +69,7 @@ func Upload(endpoint string, identifyingKey string, timestamp string, dependenci
 		return
 	}
 
-	log.Debug("Uploading to account")
+	log.Info(color.ColorString(color.White, "Uploading results to New Relic"))
 	urls, err := uploadFilesToAccount(endpoint, filesToUpload, identifyingKey, dependencies)
 	if err != nil {
 		log.Fatalf("Error uploading large file: %s", err.Error())
@@ -124,7 +124,7 @@ func uploadFile(endpoint string, files UploadFiles, attachmentKey string, deps I
 
 	wrapper := deps.GetWrapper(endpoint, reader, files.Filesize, files.NewFilename, attachmentKey)
 
-	log.Info(color.ColorString(color.White, "Uploading results to New Relic"))
+	log.Debug("Starting upload")
 	res, err := makeRequest(wrapper)
 
 	if err != nil {


### PR DESCRIPTION
# Issue

The "Uploading results to New Relic" line displays twice, it only needs to display once

# Goals

Fix the cosmetic error in the output

# Implementation Details

Moved the log.Info to a different function

# How to Test

Here's what it looks like now:

```
Creating nrdiag-output.zip
Uploading results to New Relic
 37.42 KiB / 37.42 KiB [==============================================] 100.00% 18.35 KiB/s 2s
 13.35 KiB / 13.35 KiB [==============================================] 100.00% 22.25 KiB/s 0s
Successfully uploaded to account!! Find your latest run here:
```