### PR TITLE
fix: Issue 184

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -179,7 +179,7 @@ func ProcessFilesChannel(zipfile *zip.Writer, wg *sync.WaitGroup) {
 
 // CopySingleFileToZip - takes the named file and adds it to the zip file (assumes relative location to OutputPath)
 func CopySingleFileToZip(zipfile *zip.Writer, filename string) {
-	filePath := config.Flags.OutputPath + filename
+	filePath := filepath.Join(config.Flags.OutputPath, filename)
 	_, filelistErr := os.Stat(filePath)
 	if os.IsNotExist(filelistErr) {
 		log.Debug("Could not copy file to zip: ", filename)


### PR DESCRIPTION
# Issue

https://github.com/newrelic/newrelic-diagnostics-cli/issues/184

# Goals

Ensure filelist and json are in zip when using -output-path

# Implementation Details

Ensured to use filepath.Join to build paths

# How to Test

build it and run a task with -output-path and check the resulting zip to ensure it contains the filelist and json