### PR TITLE
feat: Task updates

### DIFF
--- a/tasks/base/log/logHelpers.go
+++ b/tasks/base/log/logHelpers.go
@@ -44,8 +44,10 @@ var (
 
 var logEnvVars = []string{
 	"NRIA_LOG_FILE",                   // Infra agent
-	"NEW_RELIC_LOG",                   //.NET, Java, Node and python agent paths
-	"NEWRELIC_PROFILER_LOG_DIRECTORY", //.NET path\to\agent\directory (not configurable via config file)
+	"NEW_RELIC_LOG",                   // .NET, Java, Node and python agent paths
+	"NEWRELIC_PROFILER_LOG_DIRECTORY", // .NET path\to\agent\directory (not configurable via config file)
+	"NEW_RELIC_LOG_FILE_PATH",         // Ruby agent log path
+	"NEW_RELIC_LOG_FILE_NAME",         // Ruby agent log filename
 }
 
 var keysInConfigFile = map[string][]string{

--- a/tasks/dotnet/config/agent_windows.go
+++ b/tasks/dotnet/config/agent_windows.go
@@ -80,7 +80,7 @@ func (p DotNetConfigAgent) Execute(options tasks.Options, upstream map[string]ta
 	// no error means at least one file validated
 	return tasks.Result{
 		Status:  tasks.Success,
-		Summary: "Found" + strconv.FormatInt(int64(len(filesToAdd)), 10) + ".NET agent config files.",
+		Summary: "Found " + strconv.FormatInt(int64(len(filesToAdd)), 10) + " .NET agent config files.",
 		Payload: filesToAdd,
 	}
 }


### PR DESCRIPTION
# Issue

* Dotnet/Config/Agent success formatting 
  * `"Summary": "Found1.NET agent config files.",`
* Ruby logging env variables not included in logHelpers

# Goals

* Fix Dotnet/Config/Agent formatting
* Add Ruby logging env variables
  *  https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#log_file_name
  * https://docs.newrelic.com/docs/apm/agents/ruby-agent/configuration/ruby-agent-configuration/#log_file_path

# Implementation Details

* Updated the formatting to include spaces around the count of config files found
  * `"Summary": "Found 1 .NET agent config files.",`
* Added the env variables for ruby logs

# How to Test

`go test ./...`
Smoke test on Windows
Smoke test on host with Ruby app