### PR TITLE
fix: Base/Collector/Connect*

### DIFF
--- a/tasks/base/collector/connectEu.go
+++ b/tasks/base/collector/connectEu.go
@@ -113,7 +113,7 @@ func (p BaseCollectorConnectEU) prepareResponseErrorResult(e error, statusCode s
 		return result
 	}
 	result.Status = tasks.Warning
-	result.Summary = "Status = " + statusCode + ". When connecting to the EU Region collector, there was an issue reading the body. "
+	result.Summary = "There was an issue reading the body while connecting to the EU Region collector."
 	result.Summary += "\nPlease check network and proxy settings and try again or see -help for more options."
 	result.Summary += "Error = " + e.Error()
 	result.URL = "https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks"
@@ -124,15 +124,15 @@ func (p BaseCollectorConnectEU) prepareResponseErrorResult(e error, statusCode s
 func (p BaseCollectorConnectEU) prepareResult(body, statusCode string) tasks.Result {
 	var result tasks.Result
 
-	if statusCode == "200" {
+	if statusCode == "404" && body == "{}" {
 		log.Debug("Successfully connected")
 		result.Status = tasks.Success
-		result.Summary = "Status Code = " + statusCode
+		result.Summary = "Successfully connected to collector.eu.newrelic.com (EU Region)"
 	} else {
-		log.Debug("Non-200 response received from collector.newrelic.com:", statusCode)
+		log.Debug("Unsuccessful response received from collector.eu.newrelic.com.")
 		log.Debug("Body:", body)
 		result.Status = tasks.Warning
-		result.Summary = "collector.eu.newrelic.com (EU Region) returned a non-200 STATUS CODE: " + statusCode
+		result.Summary = "The connection to collector.eu.newrelic.com (EU Region) was not successful."
 		result.Summary += "\nPlease check network and proxy settings and try again or see -help for more options."
 		result.Summary += "\nResponse Body: " + body
 		result.URL = "https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks"

--- a/tasks/base/collector/connectEu_test.go
+++ b/tasks/base/collector/connectEu_test.go
@@ -169,16 +169,16 @@ func TestBaseCollectorConnectEU_prepareResult(t *testing.T) {
 		want   tasks.Status
 	}{
 		{
-			name: "should return a Success result given '200' status code",
+			name: "should return a Success result given '404' status code",
 			args: args{
-				body:       "mongrel ==> up (true)",
-				statusCode: "200",
+				body:       "{}",
+				statusCode: "404",
 			},
 			fields: fields{},
 			want:   tasks.Success,
 		},
 		{
-			name: "should return a Warning result given a non '200' status code",
+			name: "should return a Warning result given a non '404' status code",
 			args: args{
 				body:       "Document has moved permanently",
 				statusCode: "301",

--- a/tasks/base/collector/connectUs.go
+++ b/tasks/base/collector/connectUs.go
@@ -113,7 +113,7 @@ func (p BaseCollectorConnectUS) prepareResponseErrorResult(e error, statusCode s
 		return result
 	}
 	result.Status = tasks.Warning
-	result.Summary = "Status = " + statusCode + ". When connecting to the US Region collector, there was an issue reading the body. "
+	result.Summary = "There was an issue reading the body while connecting to the US Region collector."
 	result.Summary += "\nPlease check network and proxy settings and try again or see -help for more options."
 	result.Summary += "Error = " + e.Error()
 	result.URL = "https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks"
@@ -124,15 +124,15 @@ func (p BaseCollectorConnectUS) prepareResponseErrorResult(e error, statusCode s
 func (p BaseCollectorConnectUS) prepareResult(body, statusCode string) tasks.Result {
 	var result tasks.Result
 
-	if statusCode == "200" {
+	if statusCode == "404" && body == "{}" {
 		log.Debug("Successfully connected (US Region)")
 		result.Status = tasks.Success
-		result.Summary = "Status Code = " + statusCode
+		result.Summary = "Successfully connected to collector.newrelic.com (US Region)"
 	} else {
-		log.Debug("Non-200 response received from collector.newrelic.com:", statusCode)
+		log.Debug("Unsuccessful response received from collector.newrelic.com.")
 		log.Debug("Body:", body)
 		result.Status = tasks.Warning
-		result.Summary = "collector.newrelic.com (US Region) returned a non-200 STATUS CODE: " + statusCode
+		result.Summary = "The connection to collector.newrelic.com (US Region) was not successful."
 		result.Summary += "\nPlease check network and proxy settings and try again or see -help for more options."
 		result.Summary += "\nResponse Body: " + body
 		result.URL = "https://docs.newrelic.com/docs/apm/new-relic-apm/getting-started/networks"

--- a/tasks/base/collector/connectUs_test.go
+++ b/tasks/base/collector/connectUs_test.go
@@ -171,8 +171,8 @@ func TestBaseCollectorConnectUS_prepareResult(t *testing.T) {
 		{
 			name: "should return a Success result given '200' status code",
 			args: args{
-				body:       "mongrel ==> up (true)",
-				statusCode: "200",
+				body:       "{}",
+				statusCode: "404",
 			},
 			fields: fields{},
 			want:   tasks.Success,

--- a/tasks/base/collector/connect_helpers.go
+++ b/tasks/base/collector/connect_helpers.go
@@ -3,7 +3,7 @@ package collector
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
@@ -13,15 +13,15 @@ type requestFunc func(wrapper httpHelper.RequestWrapper) (*http.Response, error)
 
 func mockSuccessfulRequest200(wrapper httpHelper.RequestWrapper) (*http.Response, error) {
 	return &http.Response{
-		StatusCode: 200,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte("test body"))),
+		StatusCode: 404,
+		Body:       io.NopCloser(bytes.NewReader([]byte("{}"))),
 	}, nil
 }
 
 func mockUnsuccessfulRequest400(wrapper httpHelper.RequestWrapper) (*http.Response, error) {
 	return &http.Response{
 		StatusCode: 400,
-		Body:       ioutil.NopCloser(bytes.NewReader([]byte("test body"))),
+		Body:       io.NopCloser(bytes.NewReader([]byte("{}"))),
 	}, nil
 }
 


### PR DESCRIPTION
# Issue

Base/Collector/Connect* tasks are failing

# Goals

Update Base/Collector/Connect* tasks to properly detect collector connection

# Implementation Details

The new mongrel endpoint returns a 404 with `{}` for the body when the connection is successful. I updated the task to look for this.

# How to Test

`go test ./...`