### PR TITLE
fix: No longer collect executable files

### DIFF
--- a/output/output.go
+++ b/output/output.go
@@ -145,6 +145,7 @@ func ProcessFilesChannel(zipfile *zip.Writer, wg *sync.WaitGroup) {
 		log.Debug("Copying files from result: ", result.Task.Identifier().String())
 
 		for _, envelope := range result.Result.FilesToCopy {
+			log.Debug("Copying file: ", envelope.Path)
 			if !tasks.FileExists(envelope.Path) {
 				log.Debugf("File does not exist, skipping: '%s'\n", envelope.Path)
 				continue

--- a/output/output.go
+++ b/output/output.go
@@ -146,7 +146,16 @@ func ProcessFilesChannel(zipfile *zip.Writer, wg *sync.WaitGroup) {
 
 		for _, envelope := range result.Result.FilesToCopy {
 			if !tasks.FileExists(envelope.Path) {
-				log.Debugf("File does not exist: '%s'. Skipping.\n", envelope.Path)
+				log.Debugf("File does not exist, skipping: '%s'\n", envelope.Path)
+				continue
+			}
+			isExecutable, exeErr := envelope.IsExecutable()
+			if exeErr != nil {
+				log.Debugf("Unable to determine if file is executable, skipping: '%s'\n", envelope.Path)
+				continue
+			}
+			if isExecutable {
+				log.Debugf("Skipping executable file: '%s'\n", envelope.Path)
 				continue
 			}
 			// check for duplicate file paths

--- a/tasks/base/config/collect.go
+++ b/tasks/base/config/collect.go
@@ -149,6 +149,8 @@ func (p BaseConfigCollect) Execute(options tasks.Options, upstream map[string]ta
 		paths = append(paths, "/opt/newrelic/synthetics/.newrelic/synthetics/minion/")
 		paths = append(paths, "/usr/local/newrelic-netcore20-agent/")
 		paths = append(paths, "/usr/local/newrelic-dotnet-agent/") // https://github.com/newrelic/newrelic-diagnostics-cli/issues/114
+		paths = append(paths, "/opt/homebrew/etc/newrelic-infra/") // newrelic-infra.yml on Mac x86
+		paths = append(paths, "/usr/local/etc/")                   // newrelic-infra.yml on Mac arm64
 	}
 
 	//Find insecure paths

--- a/tasks/base/config/collect.go
+++ b/tasks/base/config/collect.go
@@ -149,8 +149,8 @@ func (p BaseConfigCollect) Execute(options tasks.Options, upstream map[string]ta
 		paths = append(paths, "/opt/newrelic/synthetics/.newrelic/synthetics/minion/")
 		paths = append(paths, "/usr/local/newrelic-netcore20-agent/")
 		paths = append(paths, "/usr/local/newrelic-dotnet-agent/") // https://github.com/newrelic/newrelic-diagnostics-cli/issues/114
-		paths = append(paths, "/opt/homebrew/etc/newrelic-infra/") // newrelic-infra.yml on Mac x86
-		paths = append(paths, "/usr/local/etc/")                   // newrelic-infra.yml on Mac arm64
+		paths = append(paths, "/opt/homebrew/etc/newrelic-infra/") // newrelic-infra.yml on Mac arm64
+		paths = append(paths, "/usr/local/etc/")                   // newrelic-infra.yml on Mac x86
 	}
 
 	//Find insecure paths

--- a/tasks/fileCopyEnvelope_nix.go
+++ b/tasks/fileCopyEnvelope_nix.go
@@ -1,0 +1,25 @@
+//go:build linux || darwin
+// +build linux darwin
+
+package tasks
+
+import (
+	"os"
+)
+
+// IsExecutable - checks if a file is an executable file
+func (e FileCopyEnvelope) IsExecutable() (bool, error) {
+	f, err := os.Open(e.Path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return false, err
+	}
+
+	fm := fi.Mode()
+	return fm.IsRegular() && (fm.Perm()&0111) > 0, nil
+}

--- a/tasks/fileCopyEnvelope_windows.go
+++ b/tasks/fileCopyEnvelope_windows.go
@@ -1,0 +1,12 @@
+package tasks
+
+import (
+	"strings"
+)
+
+// IsExecutable - checks if a file is an executable file
+func (e FileCopyEnvelope) IsExecutable() (bool, error) {
+	if strings.HasSuffix(e.Path, ".exe") {
+		return true, nil
+	}
+}

--- a/tasks/fileCopyEnvelope_windows.go
+++ b/tasks/fileCopyEnvelope_windows.go
@@ -9,4 +9,5 @@ func (e FileCopyEnvelope) IsExecutable() (bool, error) {
 	if strings.HasSuffix(e.Path, ".exe") {
 		return true, nil
 	}
+	return false, nil
 }

--- a/tasks/infra/log/collect.go
+++ b/tasks/infra/log/collect.go
@@ -143,7 +143,7 @@ func (p InfraLogCollect) getLogFilePaths(configElements []config.ValidateElement
 			//New log configuration allows log rotation with custom timestamp on log filename
 			if logFile != "" {
 				// search for log, rotated and gz files (filename is made with the base name of the logfile)
-				searchPattern := []string{"^" + strings.TrimSuffix(filepath.Base(logFile), filepath.Ext(logFile)) + ".+" + `(\.gz|\.zip|\` + filepath.Ext(logFile) + ")"}
+				searchPattern := []string{"^" + strings.TrimSuffix(filepath.Base(logFile), filepath.Ext(logFile)) + ".*" + `(\.gz|\.zip|\` + filepath.Ext(logFile) + ")"}
 				// Gather all files
 				filePaths = append(filePaths, p.findFiles(searchPattern, []string{filepath.Dir(logFile)})...)
 			} else {

--- a/tasks/infra/log/collect.go
+++ b/tasks/infra/log/collect.go
@@ -139,13 +139,13 @@ func (p InfraLogCollect) getLogFilePaths(configElements []config.ValidateElement
 		if configFile.Config.FileName == "newrelic-infra.yml" {
 
 			//Check desired config element for log/file new key configuration option
-			logFile := configFile.ParsedResult.FindKeyByPath("/log/file")
+			logFile := configFile.ParsedResult.FindKeyByPath("/log/file").Value()
 			//New log configuration allows log rotation with custom timestamp on log filename
-			if logFile.Value() != "" {
+			if logFile != "" {
 				// search for log, rotated and gz files (filename is made with the base name of the logfile)
-				searchPattern := []string{"^" + strings.TrimSuffix(filepath.Base(logFile.Value()), filepath.Ext(logFile.Value())) + "*"}
+				searchPattern := []string{"^" + strings.TrimSuffix(filepath.Base(logFile), filepath.Ext(logFile)) + ".+" + `(\.gz|\.zip|\` + filepath.Ext(logFile) + ")"}
 				// Gather all files
-				filePaths = append(filePaths, p.findFiles(searchPattern, []string{filepath.Dir(logFile.Value())})...)
+				filePaths = append(filePaths, p.findFiles(searchPattern, []string{filepath.Dir(logFile)})...)
 			} else {
 				//Check desired config element for log_file old key configuration option
 				foundKeys := configFile.ParsedResult.FindKey("log_file")


### PR DESCRIPTION
# Issue

IHEDIAG-649
Infra log collection can collect .exe files

# Goals

Ensure no executable files are being collected

# Implementation Details

I updated the regex that is used in the Infra/Log/Collect task to be more specific. If the infra config has a log path that ends with `newrelic-infra.log`, the regex would be
* OLD:  `^newrelic-infra*`
* NEW: `^newrelic-infra.*(.gz|.zip|.log)`

I updated the FileCopyEnvelope struct with a function to check if a file is executable. For windows it just checks if the suffix is `.exe`. For Linux/Mac, it checks the file permissions as described in [this stack overflow](https://stackoverflow.com/questions/60128401/how-to-check-if-a-file-is-executable-in-go).

I updated the paths we search for config files to include the paths for Infra on Mac installed via brew. Taken from [this doc](https://docs.newrelic.com/docs/infrastructure/install-infrastructure-agent/macos-installation/install-infrastructure-monitoring-agent-macos/#homebrew-install).

# How to Test

go test ./...

I smoke tested by:
* Running the Infra suite and confirming it collected the newrelic-infra.log
* Moving the newrelic-infra.log and replacing it with an executable file
* Running the infra suite again, and confirming that `Skipping executable file:` is in the debug logging and that the log file is not in the zip