### PR TITLE
feat: High Security Mode Refactor

### DIFF
--- a/tasks/base/config/config.go
+++ b/tasks/base/config/config.go
@@ -1,7 +1,8 @@
 package config
 
 import (
-	"github.com/newrelic/newrelic-diagnostics-cli/internal/haberdasher"
+	"strconv"
+
 	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 )
@@ -21,10 +22,32 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 	registrationFunc(BaseConfigAppName{}, true)
 	registrationFunc(BaseConfigRegionDetect{}, true)
 	registrationFunc(BaseConfigValidateHSM{
-		hsmService: haberdasherHSMService,
+		createHSMLocalValidation: createHSMLocalValidation,
+		getHSMConfiguration:      getHSMConfiguration,
 	}, true)
 }
 
-func haberdasherHSMService(licenseKeys []string) ([]haberdasher.HSMresult, *haberdasher.Response, error) {
-	return haberdasher.DefaultClient.Tasks.CheckHSM(licenseKeys)
+func createHSMLocalValidation(configElements []ValidateElement, t BaseConfigValidateHSM) map[string]bool {
+	return t.GetHSMConfigurations(configElements)
+}
+
+func getHSMConfiguration(configElement ValidateElement) bool {
+	for _, hsmName := range HSM_CONFIG_NAMES {
+		foundKeys := configElement.ParsedResult.FindKey(hsmName)
+
+		if len(foundKeys) == 0 {
+			continue
+		}
+
+		hsmStatus, ok := strconv.ParseBool(foundKeys[0].Value())
+
+		//If found field is set to something other than a bool value - implicit false
+		if ok != nil {
+			return false
+		}
+
+		return hsmStatus
+	}
+
+	return false //If no HSM field found then implicit false
 }

--- a/tasks/base/config/config_test.go
+++ b/tasks/base/config/config_test.go
@@ -1,0 +1,82 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+func Test_getHSMConfiguration(t *testing.T) {
+	type args struct {
+		configElement ValidateElement
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "No found keys with empty configElement",
+			args: args{
+				configElement: ValidateElement{},
+			},
+			want: false,
+		},
+		{
+			name: "No found keys with parseBool error",
+			args: args{
+				configElement: ValidateElement{
+					ParsedResult: tasks.ValidateBlob{
+						Key:      "high_security",
+						RawValue: "nottrue",
+					},
+					Config: ConfigElement{
+						FileName: "newrelic.yml",
+						FilePath: "/etc/",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Found key true",
+			args: args{
+				configElement: ValidateElement{
+					ParsedResult: tasks.ValidateBlob{
+						Key:      "high_security",
+						RawValue: "true",
+					},
+					Config: ConfigElement{
+						FileName: "newrelic.yml",
+						FilePath: "/etc/",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Found key false",
+			args: args{
+				configElement: ValidateElement{
+					ParsedResult: tasks.ValidateBlob{
+						Key:      "high_security",
+						RawValue: "false",
+					},
+					Config: ConfigElement{
+						FileName: "newrelic.yml",
+						FilePath: "/etc/",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getHSMConfiguration(tt.args.configElement); got != tt.want {
+				t.Errorf("getHSMConfiguration() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tasks/base/config/validateHSM.go
+++ b/tasks/base/config/validateHSM.go
@@ -63,17 +63,21 @@ func (t BaseConfigValidateHSM) Execute(options tasks.Options, upstream map[strin
 	}
 
 	t.configElements, ok = upstream["Base/Config/Validate"].Payload.([]ValidateElement)
-	if !ok || (len(t.configElements) == 0) {
+	if !ok {
+		log.Debug("Could not check configuration files for HSM validation")
+	}
+
+	if len(t.configElements) == 0 && len(t.envVars) == 0 {
 		return tasks.Result{
 			Status:  tasks.None,
-			Summary: "No New Relic configuration files to check high security mode against. Task did not run.\n",
+			Summary: "No New Relic configuration files or environment variables to check high security mode against. Task did not run.\n",
 		}
 	}
 
 	hsmValidations := t.createHSMLocalValidation(t.configElements, t)
 
 	localHSMSummary := ""
-	localHSMSummaryPattern := "Local High Security Mode setting (%v) for configuration filepath:\n\n%s\n\n"
+	localHSMSummaryPattern := "Local High Security Mode setting (%v) for configuration:\n\n\t%s\n\n"
 
 	for k, v := range hsmValidations {
 		localHSMSummary += fmt.Sprintf(localHSMSummaryPattern, v, k)
@@ -87,7 +91,6 @@ func (t BaseConfigValidateHSM) Execute(options tasks.Options, upstream map[strin
 }
 
 func (t BaseConfigValidateHSM) GetHSMConfigurations(configElements []ValidateElement) map[string]bool {
-
 	configSourcesToHSM := make(map[string]bool)
 
 	hsmEnv, ok := t.envVars[HSM_ENV_VAR]
@@ -96,6 +99,7 @@ func (t BaseConfigValidateHSM) GetHSMConfigurations(configElements []ValidateEle
 
 		if parseErr == nil {
 			configSourcesToHSM[HSM_ENV_VAR] = hsmEnvBool
+
 		}
 
 	}

--- a/tasks/base/config/validateHSM_test.go
+++ b/tasks/base/config/validateHSM_test.go
@@ -1,9 +1,9 @@
 package config
 
-// Tests for Infra/Config/IntegrationsCollect
-
 import (
-	"github.com/newrelic/newrelic-diagnostics-cli/internal/haberdasher"
+	"reflect"
+	"testing"
+
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,291 +34,255 @@ var _ = Describe("Base/Config/ValidateHSM", func() {
 
 	Describe("Dependencies()", func() {
 		It("Should return an expected slice of dependencies", func() {
-			expectedDependencies := []string{"Base/Config/ValidateLicenseKey", "Base/Config/Validate", "Base/Env/CollectEnvVars"}
+			expectedDependencies := []string{"Base/Config/Validate", "Base/Env/CollectEnvVars"}
 			Expect(p.Dependencies()).To(Equal(expectedDependencies))
 		})
 	})
 
-	Describe("Execute()", func() {
-		var (
-			result   tasks.Result
-			options  tasks.Options
-			upstream map[string]tasks.Result
-		)
-
-		JustBeforeEach(func() {
-			result = p.Execute(options, upstream)
-		})
-
-		Context("When provided multiple license keys that are hsm true and local config matches", func() {
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"Base/Config/Validate": {
-						Status: tasks.Success,
-						Payload: []ValidateElement{
-							{
-								ParsedResult: tasks.ValidateBlob{
-									Key:      "high_security",
-									RawValue: "true",
-								},
-								Config: ConfigElement{
-									FileName: "newrelic.yml",
-									FilePath: "/etc/",
-								},
-							},
-							{
-								ParsedResult: tasks.ValidateBlob{
-									Key:      "high_security",
-									RawValue: "true",
-								},
-								Config: ConfigElement{
-									FileName: "newrelic.js",
-									FilePath: "/app/",
-								},
-							},
-						},
-					},
-					"Base/Config/ValidateLicenseKey": {
-						Status: tasks.Success,
-						Payload: map[string][]string{
-							"Banana": {"/etc/newrelic.yml"},
-							"Peel":   {"/app/newrelic.js"},
-						},
-					},
-				}
-
-				p.hsmService = func(licenseKeys []string) ([]haberdasher.HSMresult, *haberdasher.Response, error) {
-					results := []haberdasher.HSMresult{}
-
-					for _, lk := range licenseKeys {
-						result := haberdasher.HSMresult{
-							LicenseKey: lk,
-							IsEnabled:  true,
-						}
-						results = append(results, result)
-					}
-
-					return results, &haberdasher.Response{}, nil
-				}
-
-			})
-
-			expectedResult := tasks.Result{
-				Status:  tasks.Success,
-				Summary: "High Security Mode setting for accounts associated with found license keys match local configuration.",
-				Payload: []HSMvalidation{
-					{
-						LicenseKey: "Banana",
-						AccountHSM: true,
-						LocalHSM: map[string]bool{
-							"/etc/newrelic.yml": true,
-						},
-					},
-					{
-						LicenseKey: "Peel",
-						AccountHSM: true,
-						LocalHSM: map[string]bool{
-							"/app/newrelic.js": true,
-						},
-					},
-				},
-			}
-
-			It("Should return a success status", func() {
-				Expect(result.Status).To(Equal(expectedResult.Status))
-			})
-
-			It("It should return a successful summary", func() {
-				Expect(result.Summary).To(Equal(expectedResult.Summary))
-			})
-
-			It("It should return a payload with an hsmValidation for each key", func() {
-				Expect(result.Payload).To(ConsistOf(expectedResult.Payload))
-			})
-		})
-
-		Context("When provided multiple license keys and one has a matching account and local hsm state, and the other does not", func() {
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"Base/Config/Validate": {
-						Status: tasks.Success,
-						Payload: []ValidateElement{
-							{
-								ParsedResult: tasks.ValidateBlob{
-									Key:      "high_security",
-									RawValue: "false",
-								},
-								Config: ConfigElement{
-									FileName: "newrelic.yml",
-									FilePath: "/etc/",
-								},
-							},
-							{
-								ParsedResult: tasks.ValidateBlob{
-									Key:      "high_security",
-									RawValue: "true",
-								},
-								Config: ConfigElement{
-									FileName: "newrelic.js",
-									FilePath: "/app/",
-								},
-							},
-						},
-					},
-					"Base/Config/ValidateLicenseKey": {
-						Status: tasks.Success,
-						Payload: map[string][]string{
-							"Banana": {"/etc/newrelic.yml"},
-							"Peel":   {"/app/newrelic.js"},
-						},
-					},
-				}
-
-				p.hsmService = func(licenseKeys []string) ([]haberdasher.HSMresult, *haberdasher.Response, error) {
-					results := []haberdasher.HSMresult{}
-
-					for _, lk := range licenseKeys {
-						result := haberdasher.HSMresult{
-							LicenseKey: lk,
-							IsEnabled:  true,
-						}
-						results = append(results, result)
-					}
-
-					return results, &haberdasher.Response{}, nil
-				}
-
-			})
-
-			expectedResult := tasks.Result{
-				Status:  tasks.Failure,
-				Summary: "High Security Mode setting (true) for account with license key:\n\nBanana\n\nmismatches configuration in:\n/etc/newrelic.yml\n\n",
-				Payload: []HSMvalidation{
-					{
-						LicenseKey: "Banana",
-						AccountHSM: true,
-						LocalHSM: map[string]bool{
-							"/etc/newrelic.yml": false,
-						},
-					},
-					{
-						LicenseKey: "Peel",
-						AccountHSM: true,
-						LocalHSM: map[string]bool{
-							"/app/newrelic.js": true,
-						},
-					},
-				},
-			}
-
-			It("Should return a failure status", func() {
-				Expect(result.Status).To(Equal(expectedResult.Status))
-			})
-
-			It("It should return a failure summary", func() {
-				Expect(result.Summary).To(Equal(expectedResult.Summary))
-			})
-
-			It("It should return a payload with an hsmValidation for each licenseKey", func() {
-				Expect(result.Payload).To(ConsistOf(expectedResult.Payload))
-			})
-		})
-
-		Context("When provided a license key that has multiple sources but one source does not match account hsm", func() {
-			BeforeEach(func() {
-				options = tasks.Options{}
-				upstream = map[string]tasks.Result{
-					"Base/Config/Validate": {
-						Status: tasks.Success,
-						Payload: []ValidateElement{
-							{
-								ParsedResult: tasks.ValidateBlob{
-									Key:      "high_security",
-									RawValue: "false",
-								},
-								Config: ConfigElement{
-									FileName: "newrelic.yml",
-									FilePath: "/etc/",
-								},
-							},
-							{
-								ParsedResult: tasks.ValidateBlob{
-									Key:      "high_security",
-									RawValue: "true",
-								},
-								Config: ConfigElement{
-									FileName: "newrelic.js",
-									FilePath: "/app/",
-								},
-							},
-						},
-					},
-					"Base/Config/ValidateLicenseKey": {
-						Status: tasks.Success,
-						Payload: map[string][]string{
-							"Banana": {"/etc/newrelic.yml", "/app/newrelic.js", "NEW_RELIC_LICENSE_KEY"},
-						},
-					},
-					"Base/Env/CollectEnvVars": {
-						Status: tasks.Success,
-						Payload: map[string]string{
-							"NEW_RELIC_HIGH_SECURITY": "true",
-						},
-					},
-				}
-
-				p.hsmService = func(licenseKeys []string) ([]haberdasher.HSMresult, *haberdasher.Response, error) {
-					results := []haberdasher.HSMresult{}
-
-					for _, lk := range licenseKeys {
-						result := haberdasher.HSMresult{
-							LicenseKey: lk,
-							IsEnabled:  false,
-						}
-						results = append(results, result)
-					}
-
-					return results, &haberdasher.Response{}, nil
-				}
-
-			})
-
-			expectedResult := tasks.Result{
-				Status:  tasks.Failure,
-				Summary: "High Security Mode setting (false) for account with license key:\n\nBanana\n\nmismatches configuration in:\n/app/newrelic.js\nNEW_RELIC_HIGH_SECURITY\n\n",
-				Payload: []HSMvalidation{
-					{
-						LicenseKey: "Banana",
-						AccountHSM: false,
-						LocalHSM: map[string]bool{
-							"/etc/newrelic.yml": false,
-							"/app/newrelic.js":  true,
-						},
-					},
-				},
-			}
-
-			It("Should return a failure status", func() {
-				Expect(result.Status).To(Equal(expectedResult.Status))
-			})
-
-			It("It should return a failure summary", func() {
-				Expect(result.Summary).To(ContainSubstring("High Security Mode setting (false) for account with license key:\n\nBanana\n\nmismatches configuration in:"))
-				Expect(result.Summary).To(ContainSubstring("\n/app/newrelic.js"))
-				Expect(result.Summary).To(ContainSubstring("\nNEW_RELIC_HIGH_SECURITY"))
-			})
-
-			It("It should return a payload with an hsmValidation with expected payload", func() {
-				Expect(result.Payload.([]HSMvalidation)[0].LicenseKey).To(Equal(expectedResult.Payload.([]HSMvalidation)[0].LicenseKey))
-				Expect(result.Payload.([]HSMvalidation)[0].AccountHSM).To(Equal(expectedResult.Payload.([]HSMvalidation)[0].AccountHSM))
-				Expect(result.Payload.([]HSMvalidation)[0].LocalHSM).To(HaveKeyWithValue("/etc/newrelic.yml", false))
-				Expect(result.Payload.([]HSMvalidation)[0].LocalHSM).To(HaveKeyWithValue("/app/newrelic.js", true))
-				Expect(result.Payload.([]HSMvalidation)[0].LocalHSM).To(HaveKeyWithValue("NEW_RELIC_HIGH_SECURITY", true))
-			})
-
-		})
-
-	})
 })
+
+func TestBaseConfigValidateHSM_Execute(t *testing.T) {
+	type fields struct {
+		configElements []ValidateElement
+		envVars        map[string]string
+	}
+	type args struct {
+		options  tasks.Options
+		upstream map[string]tasks.Result
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   tasks.Result
+		retVal map[string]bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "envVars Could not be checked for validation",
+			fields: fields{
+				configElements: []ValidateElement{
+					{
+						ParsedResult: tasks.ValidateBlob{
+							Key:      "high_security",
+							RawValue: "true",
+						},
+						Config: ConfigElement{
+							FileName: "newrelic.yml",
+							FilePath: "/etc/",
+						},
+					},
+					{
+						ParsedResult: tasks.ValidateBlob{
+							Key:      "high_security",
+							RawValue: "true",
+						},
+						Config: ConfigElement{
+							FileName: "newrelic.js",
+							FilePath: "/app/",
+						},
+					},
+				},
+				envVars: map[string]string{},
+			},
+			args: args{
+				options: tasks.Options{},
+				upstream: map[string]tasks.Result{
+					"Base/Config/Validate": {
+						Status: tasks.Success,
+						Payload: []ValidateElement{
+							{
+								ParsedResult: tasks.ValidateBlob{
+									Key:      "high_security",
+									RawValue: "true",
+								},
+								Config: ConfigElement{
+									FileName: "newrelic.yml",
+									FilePath: "/etc/",
+								},
+							},
+							{
+								ParsedResult: tasks.ValidateBlob{
+									Key:      "high_security",
+									RawValue: "true",
+								},
+								Config: ConfigElement{
+									FileName: "newrelic.js",
+									FilePath: "/app/",
+								},
+							},
+						},
+					},
+				},
+			},
+			want: tasks.Result{
+				Status:  tasks.Info,
+				Summary: "Local High Security Mode setting (true) for configuration filepath:\n\nnewrelic.yml\n\n" + "Local High Security Mode setting (false) for configuration filepath:\n\nnewrelic.js\n\n",
+				Payload: map[string]bool{
+					"newrelic.yml": true,
+					"newrelic.js":  false,
+				},
+			},
+			retVal: map[string]bool{
+				"newrelic.yml": true,
+				"newrelic.js":  false,
+			},
+		},
+		{
+			name: "No config elements to validate",
+			fields: fields{
+				configElements: []ValidateElement{},
+				envVars:        map[string]string{},
+			},
+			args: args{
+				options: tasks.Options{},
+				upstream: map[string]tasks.Result{
+					"Base/Config/Validate": {
+						Status:  tasks.Success,
+						Payload: []ValidateElement{},
+					},
+				},
+			},
+			want: tasks.Result{
+				Status:  tasks.None,
+				Summary: "No New Relic configuration files to check high security mode against. Task did not run.\n",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			createHSMLocalValTest := func([]ValidateElement, BaseConfigValidateHSM) map[string]bool {
+				return tt.retVal
+			}
+			tr := BaseConfigValidateHSM{
+				createHSMLocalValidation: createHSMLocalValTest,
+			}
+			got := tr.Execute(tt.args.options, tt.args.upstream)
+			if !reflect.DeepEqual(got.Status, tt.want.Status) {
+				t.Errorf("BaseConfigValidateHSM.Execute().Status = %v, want %v", got.Status, tt.want.Status)
+			}
+			if !reflect.DeepEqual(got.Payload, tt.want.Payload) {
+				t.Errorf("BaseConfigValidateHSM.Execute().Payload = %v, want %v", got.Payload, tt.want.Payload)
+			}
+		})
+	}
+}
+
+func TestBaseConfigValidateHSM_GetHSMConfigurations(t *testing.T) {
+	type fields struct {
+		getHSMConfiguration GetHSMConfiguration
+		envVars             map[string]string
+	}
+	type args struct {
+		configElements []ValidateElement
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]bool
+	}{
+		// TODO: Add test cases.
+		{
+			name: "Return empty map",
+			fields: fields{
+
+				getHSMConfiguration: func(ve ValidateElement) bool { return false },
+				envVars:             map[string]string{},
+			},
+			args: args{
+				configElements: []ValidateElement{},
+			},
+			want: map[string]bool{},
+		},
+		{
+			name: "Return env vars configuration",
+			fields: fields{
+
+				getHSMConfiguration: func(ve ValidateElement) bool { return false },
+				envVars: map[string]string{
+					"NEW_RELIC_HIGH_SECURITY": "true",
+				},
+			},
+			args: args{
+				configElements: []ValidateElement{},
+			},
+			want: map[string]bool{
+				"NEW_RELIC_HIGH_SECURITY": true,
+			},
+		},
+		{
+			name: "Return config files configuration",
+			fields: fields{
+				getHSMConfiguration: func(ve ValidateElement) bool { return true },
+				envVars:             map[string]string{},
+			},
+			args: args{
+				configElements: []ValidateElement{
+					{
+						ParsedResult: tasks.ValidateBlob{
+							Key:      "high_security",
+							RawValue: "true",
+						},
+						Config: ConfigElement{
+							FileName: "newrelic.yml",
+							FilePath: "/etc/",
+						},
+					},
+				},
+			},
+			want: map[string]bool{
+				"/etc/newrelic.yml": true,
+			},
+		},
+		{
+			name: "Return config files and env vars configuration",
+			fields: fields{
+				getHSMConfiguration: func(ve ValidateElement) bool { return true },
+				envVars: map[string]string{
+					"NEW_RELIC_HIGH_SECURITY": "false",
+				},
+			},
+			args: args{
+				configElements: []ValidateElement{
+					{
+						ParsedResult: tasks.ValidateBlob{
+							Key:      "high_security",
+							RawValue: "true",
+						},
+						Config: ConfigElement{
+							FileName: "newrelic.yml",
+							FilePath: "/etc/",
+						},
+					},
+					{
+						ParsedResult: tasks.ValidateBlob{
+							Key:      "high_security",
+							RawValue: "true",
+						},
+						Config: ConfigElement{
+							FileName: "newrelic.js",
+							FilePath: "/app/",
+						},
+					},
+				},
+			},
+			want: map[string]bool{
+				"NEW_RELIC_HIGH_SECURITY": false,
+				"/etc/newrelic.yml":       true,
+				"/app/newrelic.js":        true,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tr := BaseConfigValidateHSM{
+				getHSMConfiguration: tt.fields.getHSMConfiguration,
+				envVars:             tt.fields.envVars,
+			}
+			if got := tr.GetHSMConfigurations(tt.args.configElements); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("BaseConfigValidateHSM.GetHSMConfigurations() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue
HSM Refactor
# Goals
Refactor High Security Mode task to only check env vars and configuration files.  No comparison no longer happens in the CLI and instead can be sent up to their account to compare against account settings in the UI.
# Implementation Details
- Took out license key dependency from HSM task.
- Only checks env vars and configuration files for high security mode
- (Bugfix) Check config file settings for HSM
- Output info if settings are found
# How to Test
go test ./..
smoke test