### PR TITLE
fix: HSM None Result

### DIFF
--- a/tasks/base/config/validateHSM.go
+++ b/tasks/base/config/validateHSM.go
@@ -82,6 +82,12 @@ func (t BaseConfigValidateHSM) Execute(options tasks.Options, upstream map[strin
 	for k, v := range hsmValidations {
 		localHSMSummary += fmt.Sprintf(localHSMSummaryPattern, v, k)
 	}
+	if localHSMSummary == "" && len(hsmValidations) == 0 {
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: "No configurations for high security mode found.\n",
+		}
+	}
 	return tasks.Result{
 		Status:  tasks.Info,
 		Summary: localHSMSummary,

--- a/tasks/base/config/validateHSM_test.go
+++ b/tasks/base/config/validateHSM_test.go
@@ -174,6 +174,29 @@ func TestBaseConfigValidateHSM_Execute(t *testing.T) {
 			},
 			retVal: map[string]bool{"NEW_RELIC_HIGH_SECURITY": true},
 		},
+		{
+			name: "No config elements to validate but env vars exist but none contain hsm",
+			fields: fields{
+				configElements: []ValidateElement{},
+				envVars: map[string]string{
+					"NOTSECURITYMODE": "false",
+				},
+			},
+			args: args{
+				options: tasks.Options{},
+				upstream: map[string]tasks.Result{
+					"Base/Config/Validate": {
+						Status:  tasks.Success,
+						Payload: []ValidateElement{},
+					},
+				},
+			},
+			want: tasks.Result{
+				Status:  tasks.None,
+				Summary: "No configurations for high security mode found.\n",
+			},
+			retVal: map[string]bool{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
# Issue
When a combination of environment variables and configuration files are found, but don’t contain any high security mode configurations, it should return None.  Through smoke testing, I found it returned an Info result, so we need to fix that.
# Goals
Make sure a None result is returned.
# Implementation Details
Before returning an Info result, check if the summary and payload are both empty.
# How to Test
go test ./...
smoke test locally: 
- `go build`
- `cp ./newrelic-diagnostics-cli <path to service to run against> && cd <path to service to run against>`
- `NEW_RELIC_HIGH_SECURITY=false ./newrelic-diagnostics-cli -s <language of service>` OR `NEW_RELIC_HIGH_SECURITY=true ./newrelic-diagnostics-cli -s <language of service>` OR `./newrelic-diagnostics-cli -s <language of service>`
- `code nrdiag-output.json`
- `Base/Config/ValidateHSM` task should have an output that matches what you passed in to your env variable or what your configuration file contains (examples of config files are newrelic.js, newrelic.ini, newrelic.yml)
- If no configurations are found, it should return a None result