### PR TITLE
fix(NR-231490): Update Infra/Config/IntegrationsMatch: make integration_name optional

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ hog.out
 .go-version
 #coverage file
 coverage.out
+# local history 
+.history

--- a/tasks/taskHelpers.go
+++ b/tasks/taskHelpers.go
@@ -313,9 +313,8 @@ func (v ValidateBlob) PathAndKeyContains(searchKey string) bool {
 // FindKey - returns one or more ValidateBlobs within a given ValidateBlob that has the desired key
 // can return multiple nodes as it will return everything that matched path/key
 func (v ValidateBlob) FindKey(searchKey string) (results []ValidateBlob) {
-
 	//check current node for matching
-	if v.Key == searchKey {
+	if strings.EqualFold(v.Key, searchKey) {
 		log.Debug("found match, adding key", v.Key)
 		results = append(results, v)
 	}
@@ -323,12 +322,12 @@ func (v ValidateBlob) FindKey(searchKey string) (results []ValidateBlob) {
 	if !v.IsLeaf() {
 		results = append(results, v.searchChildren(searchKey)...)
 	}
+	
 	return
 }
 
 // FindKeyByPath - returns a single ValidateBlob that matches the exact full path of the Key in question. This means the searchPath parameter MUST begin with a / character
 func (v ValidateBlob) FindKeyByPath(searchPath string) ValidateBlob {
-
 	var results []ValidateBlob
 	//check current node for matching
 	if v.PathAndKey() == searchPath {
@@ -362,10 +361,8 @@ func (v ValidateBlob) FindKeyByPath(searchPath string) ValidateBlob {
 }
 
 func (v ValidateBlob) searchChildren(searchKey string) (results []ValidateBlob) {
-
 	for _, child := range v.Children {
-
-		if child.Key == searchKey {
+		if strings.EqualFold(child.Key, searchKey) {
 			log.Debug("adding", child.PathAndKey(), "to list of results")
 			results = append(results, child)
 		}
@@ -373,14 +370,13 @@ func (v ValidateBlob) searchChildren(searchKey string) (results []ValidateBlob) 
 		if !child.IsLeaf() {
 			results = append(results, child.searchChildren(searchKey)...)
 		}
-
 	}
+
 	return
 }
 
 // UpdateKey - This requires an exact path to the key in question to update and returns the original blob with just the one key value updated
 func (v ValidateBlob) UpdateKey(searchKey string, replacementValue interface{}) ValidateBlob {
-
 	log.Debug("Updating key", searchKey, "with new value", replacementValue)
 	//we're going to walk the tree, adding nodes as we find them to the new returned object and just create a new entry if and only if it's the one we want
 


### PR DESCRIPTION
# Issue

NR-231490

# Goals

Update Infra/Config/IntregrationsMatch to make integration_name optional if the configuration is v4.

# Implementation Details

Added logic to not check for integration_name if the file is v4.

I also noticed this failure:

```
Failure - Infra/Config/ValidateJMX
Unexpected results for jmx-config.yml: invalid configuration found: collection_files not set
```

The field collection_files is now in caps. Here is what the default yml looks like:

```
integrations:
- name: nri-jmx
  env:
    COLLECTION_FILES: "/etc/newrelic-infra/integrations.d/jvm-metrics.yml,/etc/newrelic-infra/integrations.d/tomcat-metrics.yml"
    JMX_HOST: jmx-host.localnet
    JMX_PASS: admin
    JMX_PORT: "9999"
    JMX_USER: admin

    # New users should leave this property as `true`, to identify the
    # monitored entities as `remote`. Setting this property to `false` (the
    # default value) is deprecated and will be removed soon, disallowing
    # entities that are identified as `local`.
    # Please check the documentation to get more information about local
    # versus remote entities:
    # https://github.com/newrelic/infra-integrations-sdk/blob/master/docs/entity-definition.md
    REMOTE_MONITORING: "true"
  interval: 15s
  labels:
    env: staging
```

So I updated the `FindKeys()` config helper function to be case insensitve.
