### PR TITLE
fix(NR-268332): Changed infra/agent/version to warning if cant validate publish date

### DIFF
--- a/tasks/infra/agent/debug.go
+++ b/tasks/infra/agent/debug.go
@@ -76,7 +76,7 @@ func (p InfraAgentDebug) Execute(options tasks.Options, upstream map[string]task
 		}
 	}
 
-	if upstream["Infra/Agent/Version"].Status != tasks.Info {
+	if upstream["Infra/Agent/Version"].Status != tasks.Info && upstream["Infra/Agent/Version"].Status != tasks.Warning {
 		return tasks.Result{
 			Status:  tasks.Failure,
 			Summary: "New Relic Infrastructure agent not detected on system. Please ensure the Infrastructure agent is installed and running.",

--- a/tasks/infra/agent/version.go
+++ b/tasks/infra/agent/version.go
@@ -123,16 +123,11 @@ func (p InfraAgentVersion) Execute(options tasks.Options, upstream map[string]ta
 		urlUpdateTask := tasks.Result{
 			URL:     "https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/update-infrastructure-agent",
 			Summary: err.Error(),
-			Status:  tasks.Error,
+			Status:  tasks.Warning,
 		}
-
-		// change task status depending on error
 		if errors.Is(err, errUnsupportedVersion) {
 			urlUpdateTask.Status = tasks.Failure
-		} else if errors.Is(err, errRecommendedUpgrade) {
-			urlUpdateTask.Status = tasks.Warning
 		}
-
 		return urlUpdateTask
 	}
 


### PR DESCRIPTION
# Issue

The Infra/Agent/Version task does a check to ensure the agent version is not out of date by pulling the data from the github api. If that connection fails, the task returns an error. This causes Infra/Agent/Debug to not gather logs and to report that the agent is not installed when it actually is.

# Goals

Have Infra/Agent/Debug run even if the agent version can't be checked against github.

# Implementation Details

Changed Infra/Agent/Version to return a warning when it can't validate the agent version isn't outdated.
Changed Infra/Agent/Debug to keep going even if Infra/Agent/Version had a warning.
