### PR TITLE
feat: allow split-namespace gathering for AgentControl

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -58,6 +58,7 @@ type userFlags struct {
 	Script             string
 	ScriptFlags        string
 	K8sNamespace       string
+	ACAgentsNamespace  string
 	InNewRelicCLI      bool
 }
 
@@ -74,53 +75,55 @@ func (f userFlags) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&struct {
-		Verbose          bool
-		Quiet            bool
-		VeryQuiet        bool
-		YesToAll         bool
-		ShowOverrideHelp bool
-		AutoAttach       bool
-		ProxySpecified   bool
-		SkipVersionCheck bool
-		Run              bool
-		ListScripts      bool
-		Tasks            string
-		ConfigFile       string
-		Override         string
-		OutputPath       string
-		Filter           string
-		BrowserURL       string
-		Suites           string
-		APIKey           string
-		Include          string
-		Region           string
-		Script           string
-		ScriptFlags      string
-		K8sNamespace     string
+		Verbose           bool
+		Quiet             bool
+		VeryQuiet         bool
+		YesToAll          bool
+		ShowOverrideHelp  bool
+		AutoAttach        bool
+		ProxySpecified    bool
+		SkipVersionCheck  bool
+		Run               bool
+		ListScripts       bool
+		Tasks             string
+		ConfigFile        string
+		Override          string
+		OutputPath        string
+		Filter            string
+		BrowserURL        string
+		Suites            string
+		APIKey            string
+		Include           string
+		Region            string
+		Script            string
+		ScriptFlags       string
+		K8sNamespace      string
+		ACAgentsNamespace string
 	}{
-		Verbose:          f.Verbose,
-		Quiet:            f.Quiet,
-		VeryQuiet:        f.VeryQuiet,
-		YesToAll:         f.YesToAll,
-		ShowOverrideHelp: f.ShowOverrideHelp,
-		AutoAttach:       f.AutoAttach,
-		ProxySpecified:   proxySpecified,
-		SkipVersionCheck: f.SkipVersionCheck,
-		Run:              f.Run,
-		ListScripts:      f.ListScripts,
-		Tasks:            f.Tasks,
-		ConfigFile:       f.ConfigFile,
-		Override:         f.Override,
-		OutputPath:       f.OutputPath,
-		Filter:           f.Filter,
-		BrowserURL:       f.BrowserURL,
-		Suites:           f.Suites,
-		Include:          f.Include,
-		APIKey:           f.APIKey,
-		Region:           f.Region,
-		Script:           f.Script,
-		ScriptFlags:      f.ScriptFlags,
-		K8sNamespace:     f.K8sNamespace,
+		Verbose:           f.Verbose,
+		Quiet:             f.Quiet,
+		VeryQuiet:         f.VeryQuiet,
+		YesToAll:          f.YesToAll,
+		ShowOverrideHelp:  f.ShowOverrideHelp,
+		AutoAttach:        f.AutoAttach,
+		ProxySpecified:    proxySpecified,
+		SkipVersionCheck:  f.SkipVersionCheck,
+		Run:               f.Run,
+		ListScripts:       f.ListScripts,
+		Tasks:             f.Tasks,
+		ConfigFile:        f.ConfigFile,
+		Override:          f.Override,
+		OutputPath:        f.OutputPath,
+		Filter:            f.Filter,
+		BrowserURL:        f.BrowserURL,
+		Suites:            f.Suites,
+		Include:           f.Include,
+		APIKey:            f.APIKey,
+		Region:            f.Region,
+		Script:            f.Script,
+		ScriptFlags:       f.ScriptFlags,
+		K8sNamespace:      f.K8sNamespace,
+		ACAgentsNamespace: f.ACAgentsNamespace,
 	})
 }
 
@@ -217,7 +220,9 @@ func ParseFlags() {
 
 	flag.StringVar(&Flags.BrowserURL, "browser-url", defaultString, "Specify a URL to check for the presence of a New Relic Browser agent")
 
-	flag.StringVar(&Flags.K8sNamespace, "k8s-namespace", defaultString, "Specify a namespace to use when executing the kubectl command")
+	flag.StringVar(&Flags.K8sNamespace, "k8s-namespace", defaultString, "Specify the namespace from where to scrape the New Relic resources. If you are using Agent-control, you can also set the '-ac-agents-namespace' flag to specify the namespace where Agent-control Agents are running.")
+
+	flag.StringVar(&Flags.ACAgentsNamespace, "ac-agents-namespace", defaultString, "Specify the namespace from where to scrape the Agent-control running agents.")
 
 	flag.BoolVar(&Flags.UsageOptOut, "usage-opt-out", false, "Decline to send anonymous New Relic Diagnostic tool usage data to New Relic for this run")
 
@@ -309,6 +314,7 @@ func (f userFlags) UsagePayload() []ConfigFlag {
 		{Name: "region", Value: f.Region},
 		{Name: "script", Value: f.Script},
 		{Name: "k8sNamespace", Value: f.K8sNamespace},
+		{Name: "aCAgentsNamespace", Value: f.ACAgentsNamespace},
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func Test_userFlags_UsagePayload(t *testing.T) {
 		Region             string
 		Script             string
 		K8sNamespace       string
+		ACAgentsNamespace  string
 	}
 
 	sampleFlags := fields{
@@ -62,6 +63,7 @@ func Test_userFlags_UsagePayload(t *testing.T) {
 		Region:             "string",
 		Script:             "string",
 		K8sNamespace:       "string",
+		ACAgentsNamespace:  "string",
 	}
 
 	samplePreparedConfig := []ConfigFlag{
@@ -89,6 +91,7 @@ func Test_userFlags_UsagePayload(t *testing.T) {
 		{Name: "region", Value: "string"},
 		{Name: "script", Value: "string"},
 		{Name: "k8sNamespace", Value: "string"},
+		{Name: "aCAgentsNamespace", Value: "string"},
 	}
 
 	tests := []struct {
@@ -131,6 +134,7 @@ func Test_userFlags_UsagePayload(t *testing.T) {
 				Region:             tt.fields.Region,
 				Script:             tt.fields.Script,
 				K8sNamespace:       tt.fields.K8sNamespace,
+				ACAgentsNamespace:  tt.fields.ACAgentsNamespace,
 			}
 			if got := f.UsagePayload(); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("userFlags.UsagePayload() = %v, want %v", got, tt.want)

--- a/output/fixtures/test-output.json
+++ b/output/fixtures/test-output.json
@@ -24,7 +24,8 @@
 		"Region": "",
 		"Script": "",
 		"ScriptFlags": "",
-		"K8sNamespace": ""
+		"K8sNamespace": "",
+		"ACAgentsNamespace": ""
 	},
 	"Results": [
 		{

--- a/output/fixtures/test-output_windows.json
+++ b/output/fixtures/test-output_windows.json
@@ -24,7 +24,8 @@
 		"Region": "",
 		"Script": "",
 		"ScriptFlags": "",
-		"K8sNamespace": ""
+		"K8sNamespace": "",
+		"ACAgentsNamespace": ""
 	},
 	"Results": [
 		{

--- a/output/fixtures/test-stream-output.json
+++ b/output/fixtures/test-stream-output.json
@@ -24,7 +24,8 @@
 		"Region": "",
 		"Script": "",
 		"ScriptFlags": "",
-		"K8sNamespace": ""
+		"K8sNamespace": "",
+		"ACAgentsNamespace": ""
 	},
 	"Results": [
 		{

--- a/output/fixtures/test-stream-output_windows.json
+++ b/output/fixtures/test-stream-output_windows.json
@@ -24,7 +24,8 @@
 		"Region": "",
 		"Script": "",
 		"ScriptFlags": "",
-		"K8sNamespace": ""
+		"K8sNamespace": "",
+		"ACAgentsNamespace": ""
 	},
 	"Results": [
 		{

--- a/processOptions.go
+++ b/processOptions.go
@@ -253,6 +253,11 @@ func processOverrides() (tasks.Options, []override) {
 		options.Options["k8sNamespace"] = config.Flags.K8sNamespace
 	}
 
+	if config.Flags.ACAgentsNamespace != "" {
+		log.Debug("Manually setting ACAgentsNamespace to ", config.Flags.ACAgentsNamespace)
+		options.Options["ACAgentsNamespace"] = config.Flags.ACAgentsNamespace
+	}
+
 	// Pass in Proxy file override value
 	if config.Flags.Proxy != "" {
 		log.Debug("Manually setting Proxy to ", config.Flags.Proxy)

--- a/tasks/k8s/flux/flux.go
+++ b/tasks/k8s/flux/flux.go
@@ -11,7 +11,7 @@ const (
 
 // RegisterWith - will register any plugins in this package
 func RegisterWith(registrationFunc func(tasks.Task, bool)) {
-	log.Debug("Registering K8s/Helm/*")
+	log.Debug("Registering K8s/Flux/*")
 	registrationFunc(FluxCharts{
 		cmdExec: tasks.CmdExecutor,
 	}, true)

--- a/tasks/k8s/resources/config.go
+++ b/tasks/k8s/resources/config.go
@@ -16,7 +16,7 @@ func (p K8sConfigs) Identifier() tasks.Identifier {
 
 // Explain - Returns the help text for each individual task
 func (p K8sConfigs) Explain() string {
-	return "Collects K8s configMaps for the given namespace in YAML format."
+	return "Collects K8s configMaps for the given namespaces in YAML format."
 }
 
 // Dependencies - Returns the dependencies for each task.
@@ -26,13 +26,9 @@ func (p K8sConfigs) Dependencies() []string {
 
 // Execute - The core work within each task
 func (p K8sConfigs) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
-	var (
-		res []byte
-		err error
-	)
+	stream := make(chan string)
 
-	namespace := options.Options["k8sNamespace"]
-	res, err = p.runCommand(namespace)
+	result, err := getResources(options, p.runCommand)
 	if err != nil {
 		return tasks.Result{
 			Summary: "Error retrieving configMaps: " + err.Error(),
@@ -40,8 +36,7 @@ func (p K8sConfigs) Execute(options tasks.Options, upstream map[string]tasks.Res
 		}
 	}
 
-	stream := make(chan string)
-	go tasks.StreamBlob(string(res), stream)
+	go tasks.StreamBlob(string(result), stream)
 
 	return tasks.Result{
 		Summary:     "Successfully collected K8s configMaps ",

--- a/tasks/k8s/resources/daemonset.go
+++ b/tasks/k8s/resources/daemonset.go
@@ -26,22 +26,17 @@ func (p K8sDaemonset) Dependencies() []string {
 
 // Execute - The core work within each task
 func (p K8sDaemonset) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
-	var (
-		res []byte
-		err error
-	)
+	stream := make(chan string)
 
-	namespace := options.Options["k8sNamespace"]
-	res, err = p.runCommand(namespace)
+	result, err := getResources(options, p.runCommand)
 	if err != nil {
 		return tasks.Result{
-			Summary: "Error retrieving daemonset details: " + err.Error(),
+			Summary: "Error retrieving daemonsets details: " + err.Error(),
 			Status:  tasks.Error,
 		}
 	}
 
-	stream := make(chan string)
-	go tasks.StreamBlob(string(res), stream)
+	go tasks.StreamBlob(string(result), stream)
 
 	return tasks.Result{
 		Summary:     "Successfully collected K8s newrelic-infrastructure daemonset",

--- a/tasks/k8s/resources/deploy.go
+++ b/tasks/k8s/resources/deploy.go
@@ -26,22 +26,17 @@ func (p K8sDeployment) Dependencies() []string {
 
 // Execute - The core work within each task
 func (p K8sDeployment) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
-	var (
-		res []byte
-		err error
-	)
+	stream := make(chan string)
 
-	namespace := options.Options["k8sNamespace"]
-	res, err = p.runCommand(namespace)
+	result, err := getResources(options, p.runCommand)
 	if err != nil {
 		return tasks.Result{
-			Summary: "Error retrieving deployment details: " + err.Error(),
+			Summary: "Error retrieving deployments details: " + err.Error(),
 			Status:  tasks.Error,
 		}
 	}
 
-	stream := make(chan string)
-	go tasks.StreamBlob(string(res), stream)
+	go tasks.StreamBlob(string(result), stream)
 
 	return tasks.Result{
 		Summary:     "Successfully collected K8s newrelic-infrastructure deployment",

--- a/tasks/k8s/resources/pods.go
+++ b/tasks/k8s/resources/pods.go
@@ -26,22 +26,17 @@ func (p K8sPods) Dependencies() []string {
 
 // Execute - The core work within each task
 func (p K8sPods) Execute(options tasks.Options, upstream map[string]tasks.Result) tasks.Result {
-	var (
-		res []byte
-		err error
-	)
+	stream := make(chan string)
 
-	namespace := options.Options["k8sNamespace"]
-	res, err = p.runCommand(namespace)
+	result, err := getResources(options, p.runCommand)
 	if err != nil {
 		return tasks.Result{
-			Summary: "Error retrieving pods: " + err.Error(),
+			Summary: "Error retrieving pods details: " + err.Error(),
 			Status:  tasks.Error,
 		}
 	}
 
-	stream := make(chan string)
-	go tasks.StreamBlob(string(res), stream)
+	go tasks.StreamBlob(string(result), stream)
 
 	return tasks.Result{
 		Summary:     "Successfully collected K8s newrelic-infrastructure pods",

--- a/tasks/k8s/resources/resources.go
+++ b/tasks/k8s/resources/resources.go
@@ -23,3 +23,27 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		cmdExec: tasks.CmdExecutor,
 	}, true)
 }
+
+func getResources(
+	options tasks.Options,
+	runCommand func(namespace string) ([]byte, error),
+) ([]byte, error) {
+	namespace := options.Options["k8sNamespace"]
+	namespaces := []string{namespace}
+
+	agentsNamespace := options.Options["ACAgentsNamespace"]
+	if agentsNamespace != "" && agentsNamespace != namespace {
+		namespaces = append(namespaces, agentsNamespace)
+	}
+
+	var result []byte
+	for _, ns := range namespaces {
+		res, err := runCommand(ns)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, res...)
+	}
+
+	return result, nil
+}


### PR DESCRIPTION
On newest versions of AC 2 namespaces are used the main one and one for the agents.
This task allows adding a flag specifying an the extra namespace where the agent control agents reside.
The Resources will be scrapped from both namespaces,