### PR TITLE
feat(logs): collecting as well instal job logs

### DIFF
--- a/tasks/k8s/agentcontrol/agentcontrol.go
+++ b/tasks/k8s/agentcontrol/agentcontrol.go
@@ -25,6 +25,11 @@ func RegisterWith(registrationFunc func(tasks.Task, bool)) {
 		appName:       "agent-control",
 		labelSelector: "app.kubernetes.io/name=agent-control",
 	}, true)
+	registrationFunc(K8sAgentControlLogs{
+		cmdExec:       tasks.CmdExecutor,
+		appName:       "agent-control-install-job",
+		labelSelector: "job-name=agent-control-install-job",
+	}, true)
 	registrationFunc(K8sAgentControlStatusServer{
 		cmdExec:       tasks.CmdExecutor,
 		appName:       "agent-control",


### PR DESCRIPTION
Collecting as well agent-control-install-job logs

Tested locally:
```
[pod/agent-control-install-job-5kfzl/install-agent-control-deployment] 2025-07-18T12:58:39  INFO Applying agent control resources
[pod/agent-control-install-job-5kfzl/install-agent-control-deployment] 2025-07-18T12:58:39  INFO Applying HelmRepository with name "agent-control"
[pod/agent-control-install-job-5kfzl/install-agent-control-deployment] 2025-07-18T12:58:39  INFO HelmRepository with name agent-control applied successfully
[pod/agent-control-install-job-5kfzl/install-agent-control-deployment] 2025-07-18T12:58:39  INFO Applying HelmRelease with name "agent-control-deployment"
[pod/agent-control-install-job-5kfzl/install-agent-control-deployment] 2025-07-18T12:58:39  INFO HelmRelease with name agent-control-deployment applied successfully
[pod/agent-control-install-job-5kfzl/install-agent-control-deployment] 2025-07-18T12:58:39  INFO Agent control resources applied successfully
[pod/agent-control-install-job-5kfzl/install-agent-control-deployment] 2025-07-18T12:58:39  INFO Checking Agent control installation
```