### PR TITLE
fix: Update compatible version check for Jboss EAP

### DIFF
--- a/tasks/java/appserver/jbosseap.go
+++ b/tasks/java/appserver/jbosseap.go
@@ -224,7 +224,7 @@ func (p JavaAppserverJbossEapCheck) getJbossFileLinux() (string, error) {
 }
 
 func versionCheckJboss(version string) (status tasks.Status, summary string) {
-	compatibilityRequirements := []string{"6-6.*"}
+	compatibilityRequirements := []string{"6-"}
 	versionSplit := strings.Split(version, ".")
 	var err error
 	isCompatible := false


### PR DESCRIPTION
# Issue

Java APM agent now support JBoss EAP 6.0 to latest: 
https://docs.newrelic.com/docs/apm/agents/java-agent/getting-started/compatibility-requirements-java-agent/#app-web-servers