### PR TITLE
fix(glibc): Ensuring nrdiag uses pure Go

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: golangci-lint
 on:
   pull_request:
-   paths-ignore:
+    paths-ignore:
       - 'README.md'
       - '*_test.go'
 jobs:
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         go-version: [1.22.x]
-        # os: [ubuntu-latest]
         os: [ubuntu-latest, macos-latest, windows-latest]
     name: lint
     runs-on: ${{ matrix.os }}
@@ -18,13 +17,26 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+
+      - name: Check for Cgo dependencies
+        run: |
+          echo "Searching for packages that require Cgo..."
+          CGO_PACKAGES=$(go list -f '{{if .CgoFiles}}{{.ImportPath}}{{end}}' -tags cgo ./...)
+          if [ -n "$CGO_PACKAGES" ]; then
+            echo "::error::Found packages that require Cgo, which is not allowed."
+            echo "This will result in a dynamically linked binary."
+            echo "The following packages must be removed or refactored:"
+            echo "$CGO_PACKAGES"
+            # Exit with a non-zero status to fail the workflow
+            exit 1
+          else
+            echo "Success: No Cgo dependencies found."
+          fi
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
           version: v1.63
-
-          # Optional: golangci-lint command line arguments.
           args: --timeout=5m
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
+

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,7 @@ jobs:
           go-version: ${{ matrix.go-version }}
 
       - name: Check for Cgo dependencies
+        shell: bash
         run: |
           echo "Searching for packages that require Cgo..."
           CGO_PACKAGES=$(go list -f '{{if .CgoFiles}}{{.ImportPath}}{{end}}' -tags cgo ./...)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,10 +36,7 @@ fi
 VERSION=$(cat releaseVersion.txt | awk -F'majorMinor=' '{printf$2}')
 
 BUILD_TIMESTAMP=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
-LDFLAGS="-s -w -X ${CONFIG_PATH}.Version=${VERSION}.${VERSION_NUMBER} -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.USUsageEndpoint=${US_USAGE_ENDPOINT} -X ${CONFIG_PATH}.USAttachmentEndpoint=${US_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.USHaberdasherURL=${US_HABERDASHER_URL} -X ${CONFIG_PATH}.EUUsageEndpoint=${EU_USAGE_ENDPOINT} -X ${CONFIG_PATH}.EUAttachmentEndpoint=${EU_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.EUHaberdasherURL=${EU_HABERDASHER_URL}"
-
-# Disable CGO to ensure we're using pure go and to fix 'version `GLIBC_2.34' not found' errors
-CGO_ENABLED=0
+LDFLAGS="-s -w -extldflags '-static' -X ${CONFIG_PATH}.Version=${VERSION}.${VERSION_NUMBER} -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.USUsageEndpoint=${US_USAGE_ENDPOINT} -X ${CONFIG_PATH}.USAttachmentEndpoint=${US_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.USHaberdasherURL=${US_HABERDASHER_URL} -X ${CONFIG_PATH}.EUUsageEndpoint=${EU_USAGE_ENDPOINT} -X ${CONFIG_PATH}.EUAttachmentEndpoint=${EU_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.EUHaberdasherURL=${EU_HABERDASHER_URL}"
 
 # Set version based on version.txt file and auto version number
 echo "Build version is $VERSION.$VERSION_NUMBER"
@@ -52,29 +49,29 @@ echo "running GOOS=windows go get -t ./..."
 $(GOOS=windows go get -t ./...)
 
 echo "Building Mac x64 $EXENAME"
-GOOS=darwin GOARCH=amd64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/mac/${EXENAME}_x64")
 
 echo "Building Mac arm64 $EXENAME"
-GOOS=darwin GOARCH=arm64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/mac/${EXENAME}_arm64")
 
 echo "Building Linux x64"
-GOOS=linux GOARCH=amd64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/linux/${EXENAME}_x64")
 
 echo "Building Linux arm64"
-GOOS=linux GOARCH=arm64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/linux/${EXENAME}_arm64")
 
 echo "Building Windows 386"
-GOOS=windows GOARCH=386 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/win/$EXENAME.exe")
 
 echo "Building Windows x64"
-GOOS=windows GOARCH=amd64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/win/${EXENAME}_x64.exe")
 
 echo "Building Windows arm64"
-GOOS=windows GOARCH=arm64 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/win/${EXENAME}_arm64.exe")

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -36,7 +36,7 @@ fi
 VERSION=$(cat releaseVersion.txt | awk -F'majorMinor=' '{printf$2}')
 
 BUILD_TIMESTAMP=$(date -u '+%Y-%m-%d_%I:%M:%S%p')
-LDFLAGS="-s -w -extldflags '-static' -X ${CONFIG_PATH}.Version=${VERSION}.${VERSION_NUMBER} -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.USUsageEndpoint=${US_USAGE_ENDPOINT} -X ${CONFIG_PATH}.USAttachmentEndpoint=${US_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.USHaberdasherURL=${US_HABERDASHER_URL} -X ${CONFIG_PATH}.EUUsageEndpoint=${EU_USAGE_ENDPOINT} -X ${CONFIG_PATH}.EUAttachmentEndpoint=${EU_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.EUHaberdasherURL=${EU_HABERDASHER_URL}"
+LDFLAGS="-s -w -X ${CONFIG_PATH}.Version=${VERSION}.${VERSION_NUMBER} -X ${CONFIG_PATH}.BuildTimestamp=${BUILD_TIMESTAMP} -X ${CONFIG_PATH}.USUsageEndpoint=${US_USAGE_ENDPOINT} -X ${CONFIG_PATH}.USAttachmentEndpoint=${US_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.USHaberdasherURL=${US_HABERDASHER_URL} -X ${CONFIG_PATH}.EUUsageEndpoint=${EU_USAGE_ENDPOINT} -X ${CONFIG_PATH}.EUAttachmentEndpoint=${EU_ATTACHMENT_ENDPOINT} -X ${CONFIG_PATH}.EUHaberdasherURL=${EU_HABERDASHER_URL}"
 
 # Set version based on version.txt file and auto version number
 echo "Build version is $VERSION.$VERSION_NUMBER"
@@ -49,29 +49,29 @@ echo "running GOOS=windows go get -t ./..."
 $(GOOS=windows go get -t ./...)
 
 echo "Building Mac x64 $EXENAME"
-GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build -tags netgo -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/mac/${EXENAME}_x64")
 
 echo "Building Mac arm64 $EXENAME"
-GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build -tags netgo -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/mac/${EXENAME}_arm64")
 
 echo "Building Linux x64"
-GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags netgo -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/linux/${EXENAME}_x64")
 
 echo "Building Linux arm64"
-GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build -tags netgo -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/linux/${EXENAME}_arm64")
 
 echo "Building Windows 386"
-GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=windows GOARCH=386 CGO_ENABLED=0 go build -tags netgo -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/win/$EXENAME.exe")
 
 echo "Building Windows x64"
-GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -tags netgo -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/win/${EXENAME}_x64.exe")
 
 echo "Building Windows arm64"
-GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -o "$TEMPNAME" -ldflags "$LDFLAGS"
+GOOS=windows GOARCH=arm64 CGO_ENABLED=0 go build -tags netgo -o "$TEMPNAME" -ldflags "$LDFLAGS"
 $(mv "$TEMPNAME" "bin/win/${EXENAME}_arm64.exe")

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Running build script"
-CGO_ENABLED=0 ./scripts/build.sh
+./scripts/build.sh
 
 VERSION_NUMBER=$BUILD_NUMBER
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,7 +3,7 @@
 set -e
 
 echo "Running build script"
-./scripts/build.sh
+CGO_ENABLED=0 ./scripts/build.sh
 
 VERSION_NUMBER=$BUILD_NUMBER
 


### PR DESCRIPTION
# Issue

When running the build script locally and testing, I do not receive any errors on any linux distros and the binary is statically linked

```
$ ldd nrdiag_x64
	not a dynamic executable
```

However the binaries that are being built by our release pipeline result in the following errors on Rocky Linux 8:

```
./nrdiag: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by ./nrdiag)
./nrdiag: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ./nrdiag)
```

which is caused by them being dynamically linked:

```
$ ldd nrdiag
./nrdiag: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by ./nrdiag)
./nrdiag: /lib64/libc.so.6: version `GLIBC_2.32' not found (required by ./nrdiag)
	linux-vdso.so.1 (0x00007ffd281ec000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f6869ace000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6869ea4000)
```

# Implementation Details

* Moved the CGO_ENABLED=0 setting to the go build calls directly
* Added netgo tag to ensure pure go is used for net library
* Added check to lint.yml to fail PR if any package that uses cgo is used

# How to Test

I was unable to reproduce the issue when building locally, even using tools like [act](https://github.com/nektos/act) to try and reproduce the github actions.