### PR TITLE
fix(tests): Apply more fixes for Windows Integration test flakiness

### DIFF
--- a/tasks/infra/agent/integrationTests_windows.yml
+++ b/tasks/infra/agent/integrationTests_windows.yml
@@ -3,7 +3,8 @@
       - ADD https://download.newrelic.com/infrastructure_agent/binaries/windows/amd64/newrelic-infra-amd64.1.77.1.zip C:/nra.zip
       - RUN Expand-Archive -Path 'C:\nra.zip' -DestinationPath 'C:\' -Force; Write-Host '=== EXTRACTED CONTENTS ==='; Get-ChildItem 'C:\Program Files\New Relic\newrelic-infra\' | Select-Object FullName
       - COPY ["tasks/infra/config/fixtures/minimal_infra_config/newrelic-infra.yml", "C:/Program Files/New Relic/newrelic-infra/newrelic-infra.yml"]
-    docker_cmd: ./nrdiag_x64.exe -y -filter all
+      - RUN (Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ') | Out-File -FilePath C:/app/release_date.txt -Encoding ascii -NoNewline
+    docker_cmd: $d = Get-Content C:/app/release_date.txt; ./nrdiag_x64.exe -y -filter all -o Infra/Agent/Version.releaseDateOverride=$d
     log_entry_expected:
      - Info.*Infra/Agent/Version.*
     log_entry_not_expected:

--- a/tasks/infra/agent/version.go
+++ b/tasks/infra/agent/version.go
@@ -19,6 +19,8 @@ var (
 	errRecommendedUpgrade = fmt.Errorf("New Relic Infrastructure Agent upgrade is recommended, installed agent was released more than one year ago")
 )
 
+const releaseDateOverrideKey = "releaseDateOverride"
+
 type githubReleaseData struct {
 	PublishedAt string `json:"published_at"`
 }
@@ -118,7 +120,7 @@ func (p InfraAgentVersion) Execute(options tasks.Options, upstream map[string]ta
 		}
 	}
 
-	err = p.validatePublishDate(ver)
+	err = p.validatePublishDate(ver, options)
 	if err != nil {
 		urlUpdateTask := tasks.Result{
 			URL:     "https://docs.newrelic.com/docs/infrastructure/new-relic-infrastructure/installation/update-infrastructure-agent",
@@ -166,13 +168,13 @@ func (p InfraAgentVersion) getBinaryPath(envVars map[string]string) (string, err
 }
 
 // validatePublishDate returns an error if the version was released more than one year ago
-func (p InfraAgentVersion) validatePublishDate(version tasks.Ver) error {
+func (p InfraAgentVersion) validatePublishDate(version tasks.Ver, options tasks.Options) error {
 	// Github releases started on version 1.12.0
 	if version.IsLessThanEq(oldestGithubRelease) {
 		return errUnsupportedVersion
 	}
 
-	publishData, err := p.getGithubPublishDate(fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Patch))
+	publishData, err := p.getGithubPublishDate(fmt.Sprintf("%d.%d.%d", version.Major, version.Minor, version.Patch), options)
 	if err != nil {
 		return fmt.Errorf("Unable to get New Relic Infrastructure Agent release date: %w", err)
 	}
@@ -187,7 +189,12 @@ func (p InfraAgentVersion) validatePublishDate(version tasks.Ver) error {
 	return nil
 }
 
-func (p InfraAgentVersion) getGithubPublishDate(version string) (time.Time, error) {
+func (p InfraAgentVersion) getGithubPublishDate(version string, options tasks.Options) (time.Time, error) {
+	if override := options.Options[releaseDateOverrideKey]; override != "" {
+		log.Debug("Infra/Agent/Version - using releaseDateOverride, skipping GitHub API call")
+		return time.Parse(time.RFC3339, override)
+	}
+
 	wrapper := httpHelper.RequestWrapper{
 		Method:         "GET",
 		URL:            githubAPIReleaseURL + version,

--- a/tasks/infra/agent/version_test.go
+++ b/tasks/infra/agent/version_test.go
@@ -5,7 +5,7 @@ package agent
 import (
 	"bytes"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -145,7 +145,7 @@ var _ = Describe("Infra/Agent/Version", func() {
 				p.runtimeOS = "darwin"
 				p.httpGetter = func(wrapper httpHelper.RequestWrapper) (*http.Response, error) {
 					return &http.Response{
-						Body: ioutil.NopCloser(bytes.NewReader([]byte(`{"published_at": "2022-11-17T10:50:43Z"}`))),
+						Body: io.NopCloser(bytes.NewReader([]byte(`{"published_at": "2022-11-17T10:50:43Z"}`))),
 					}, nil
 				}
 				p.now = func() time.Time { return time.Date(2022, time.Month(11), 21, 1, 10, 30, 0, time.UTC) }
@@ -180,7 +180,7 @@ var _ = Describe("Infra/Agent/Version", func() {
 				p.runtimeOS = "darwin"
 				p.httpGetter = func(wrapper httpHelper.RequestWrapper) (*http.Response, error) {
 					return &http.Response{
-						Body: ioutil.NopCloser(bytes.NewReader([]byte(`{"published_at": "2020-11-17T10:50:43Z"}`))),
+						Body: io.NopCloser(bytes.NewReader([]byte(`{"published_at": "2020-11-17T10:50:43Z"}`))),
 					}, nil
 				}
 				p.now = func() time.Time { return time.Date(2022, time.Month(11), 21, 1, 10, 30, 0, time.UTC) }
@@ -355,13 +355,15 @@ var _ = Describe("Infra/Agent/Version", func() {
 			var (
 				version tasks.Ver
 				err     error
+				options tasks.Options
 			)
 
 			JustBeforeEach(func() {
-				err = p.validatePublishDate(version)
+				err = p.validatePublishDate(version, options)
 			})
 			Context("Version prior to 1.12.0", func() {
 				BeforeEach(func() {
+					options = tasks.Options{}
 					version = tasks.Ver{Major: 1, Minor: 11, Patch: 0, Build: 0}
 				})
 
@@ -372,16 +374,50 @@ var _ = Describe("Infra/Agent/Version", func() {
 
 			Context("Up-to-date version", func() {
 				BeforeEach(func() {
+					options = tasks.Options{}
 					version = tasks.Ver{Major: 1, Minor: 33, Patch: 0, Build: 0}
 					p.httpGetter = func(wrapper httpHelper.RequestWrapper) (*http.Response, error) {
 						return &http.Response{
-							Body: ioutil.NopCloser(bytes.NewReader([]byte(`{"published_at": "2021-11-22T10:50:43Z"}`))),
+							Body: io.NopCloser(bytes.NewReader([]byte(`{"published_at": "2021-11-22T10:50:43Z"}`))),
 						}, nil
 					}
 					p.now = func() time.Time { return time.Date(2022, time.Month(11), 21, 1, 10, 30, 0, time.UTC) }
 				})
 
 				It("should not return an error", func() {
+					Expect(err).To(BeNil())
+				})
+			})
+
+			Context("releaseDateOverride option is provided", func() {
+				BeforeEach(func() {
+					version = tasks.Ver{Major: 1, Minor: 77, Patch: 1, Build: 0}
+					options = tasks.Options{Options: map[string]string{releaseDateOverrideKey: "2026-07-13T18:04:00Z"}}
+					p.now = func() time.Time { return time.Date(2026, time.Month(7), 13, 18, 5, 0, 0, time.UTC) }
+					p.httpGetter = func(wrapper httpHelper.RequestWrapper) (*http.Response, error) {
+						Fail("httpGetter must not be called when releaseDateOverride is set")
+						return nil, nil
+					}
+				})
+
+				It("should not return an error and should not hit the network", func() {
+					Expect(err).To(BeNil())
+				})
+			})
+
+			Context("releaseDateOverride option is empty", func() {
+				BeforeEach(func() {
+					version = tasks.Ver{Major: 1, Minor: 33, Patch: 0, Build: 0}
+					options = tasks.Options{Options: map[string]string{releaseDateOverrideKey: ""}}
+					p.httpGetter = func(wrapper httpHelper.RequestWrapper) (*http.Response, error) {
+						return &http.Response{
+							Body: io.NopCloser(bytes.NewReader([]byte(`{"published_at": "2021-11-22T10:50:43Z"}`))),
+						}, nil
+					}
+					p.now = func() time.Time { return time.Date(2022, time.Month(11), 21, 1, 10, 30, 0, time.UTC) }
+				})
+
+				It("should fall back to the GitHub API path", func() {
 					Expect(err).To(BeNil())
 				})
 			})


### PR DESCRIPTION
## Summary
The `InfrastructureVersionPresentWindows` integration test has been failing on and off. It exercises `Infra/Agent/Version`, which reports `Info` only after calling the GitHub API to check how old the installed agent is. That call is unauthenticated and rate-limited to 60 requests/hour per IP, and the Windows runners share IPs, so the call frequently gets throttled. When it does, the task returns `Warning` instead of `Info` and the test fails. Re-running the same commit passes, which is what pointed to the rate limit rather than a real regression.

## Fix
Instead of depending on that network call, the test now hands the release date directly to the task via the `-o` override the CLI already supports. Nothing changes in production: when the override isn't set, the task calls GitHub exactly as before. The date the test passes in is generated from the current date at image-build time, so it always looks recent and won't silently rot into a failure a year out the way a hardcoded date would.

The version-age logic is already unit-tested, so this doesn't drop meaningful coverage. The integration test goes back to verifying what it's actually for: that the installed agent binary is found and its version is read end to end.