### PR TITLE
feat: add new suite for onhost agent control

### DIFF
--- a/processOptions.go
+++ b/processOptions.go
@@ -127,7 +127,7 @@ func printSuites() {
 	}
 	log.Infof("Usage: \n\t%s --suites [suite arguments] \nExamples:\n\t%[1]s --suites java,infra\n\t%[1]s --suites python\n", command)
 	log.Info("\nUse the following arguments to select task suite(s) to run:\n")
-	log.Infof("%-18s%s\n\n", "Arguments:", "Diagnostics for:")
+	log.Infof("%-25s%s\n\n", "Arguments:", "Diagnostics for:")
 
 	for _, suite := range suites.DefaultSuiteManager.Suites {
 
@@ -136,7 +136,7 @@ func printSuites() {
 			description = suite.DisplayName
 		}
 
-		log.Infof("%-18s%s\n", suite.Identifier, description)
+		log.Infof("%-25s%s\n", suite.Identifier, description)
 	}
 	log.Info("\n")
 }

--- a/registration/registerTasks.go
+++ b/registration/registerTasks.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+	agentControlAgent "github.com/newrelic/newrelic-diagnostics-cli/tasks/agentcontrol/agent"
+	agentControlConfig "github.com/newrelic/newrelic-diagnostics-cli/tasks/agentcontrol/config"
 	androidAgent "github.com/newrelic/newrelic-diagnostics-cli/tasks/android/agent"
 	androidConfig "github.com/newrelic/newrelic-diagnostics-cli/tasks/android/config"
 	androidLog "github.com/newrelic/newrelic-diagnostics-cli/tasks/android/log"
@@ -129,6 +131,8 @@ func init() {
 	k8sAgentControl.RegisterWith(Register)
 	flux.RegisterWith(Register)
 	K8sHelm.RegisterWith(Register)
+	agentControlAgent.RegisterWith(Register)
+	agentControlConfig.RegisterWith(Register)
 
 	//example stuff, doesn't need to "ship" because binary gets name after directory with `go build` cmd
 	if strings.Contains(os.Args[0], "newrelic-diagnostics-cli") {

--- a/suites/suiteDefinitions.go
+++ b/suites/suiteDefinitions.go
@@ -137,6 +137,15 @@ var suiteDefinitions = []Suite{
 		},
 	},
 	{
+		Identifier:  "onhost-agent-control",
+		DisplayName: "Agent Control on Host",
+		Description: "Gather information about agent-control logs, status, connectivity and resources on the host",
+		Tasks: []string{
+			"AgentControl/Agent/*",
+			"AgentControl/Config/*",
+		},
+	},
+	{
 		Identifier:  "all",
 		DisplayName: "All New Relic Products",
 		Description: "We only recommend this option if you are unsure of the NR product you are troubleshooting.",

--- a/tasks/agentcontrol/agent/agentcontrol.go
+++ b/tasks/agentcontrol/agent/agentcontrol.go
@@ -1,0 +1,28 @@
+package agentcontrol
+
+import (
+	"net/http"
+	"os"
+
+	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+type requestFunc func(wrapper httpHelper.RequestWrapper) (*http.Response, error)
+
+// RegisterWith - will register any plugins in this package
+func RegisterWith(registrationFunc func(tasks.Task, bool)) {
+	log.Debug("Registering AgentControl/Agent/*")
+	registrationFunc(AgentControlStatusServer{
+		httpGetter:   httpHelper.MakeHTTPRequest,
+		configReader: os.ReadFile,
+	}, true)
+	registrationFunc(AgentControlAgentConnect{
+		httpGetter:   httpHelper.MakeHTTPRequest,
+		configReader: os.ReadFile,
+	}, true)
+	registrationFunc(AgentControlLogCollect{
+		cmdExec: tasks.CmdExecutor,
+	}, true)
+}

--- a/tasks/agentcontrol/agent/connect.go
+++ b/tasks/agentcontrol/agent/connect.go
@@ -1,0 +1,341 @@
+package agentcontrol
+
+import (
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"runtime"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+const (
+	defaultOpAMPEndpoint = "https://opamp.service.newrelic.com/v1/opamp"
+	defaultJWKSEndpoint  = "https://publickeys.newrelic.com/r/blob-management/global/agentconfiguration/jwks.json"
+	defaultOAuthEndpoint = "https://system-identity-oauth.service.newrelic.com/oauth2/token"
+	defaultStatusHost    = "127.0.0.1"
+	defaultStatusPort    = 51200
+)
+
+var acLocalConfigPath = func() string {
+	if runtime.GOOS == "windows" {
+		return `C:\Program Files\New Relic\newrelic-agent-control\local-data\agent-control\local_config.yaml`
+	}
+	return "/etc/newrelic-agent-control/local-data/agent-control/local_config.yaml"
+}()
+
+// acConfig mirrors only the fields of local_config.yaml that we need.
+type acConfig struct {
+	FleetControl struct {
+		Endpoint            string `yaml:"endpoint"`
+		SignatureValidation struct {
+			PublicKeyServerURL string `yaml:"public_key_server_url"`
+		} `yaml:"signature_validation"`
+		AuthConfig struct {
+			TokenURL       string `yaml:"token_url"`
+			ClientID       string `yaml:"client_id"`
+			PrivateKeyPath string `yaml:"private_key_path"`
+		} `yaml:"auth_config"`
+	} `yaml:"fleet_control"`
+	Server struct {
+		Enabled bool   `yaml:"enabled"`
+		Host    string `yaml:"host"`
+		Port    int    `yaml:"port"`
+	} `yaml:"server"`
+}
+
+// readACConfig parses the agent-control local config file.
+// Returns a zero-value acConfig and a non-nil error if the file is missing or unparseable.
+func readACConfig(reader func(string) ([]byte, error)) (acConfig, error) {
+	data, err := reader(acLocalConfigPath)
+	if err != nil {
+		return acConfig{}, err
+	}
+	var cfg acConfig
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return acConfig{}, err
+	}
+	return cfg, nil
+}
+
+// ConnectResult holds the outcome of a single endpoint connectivity check.
+type ConnectResult struct {
+	URL        string
+	Reachable  bool
+	StatusCode int
+	Note       string
+}
+
+// KeyValidationResult holds the outcome of the local private key file check.
+type KeyValidationResult struct {
+	Path  string
+	Valid bool
+	Note  string
+}
+
+// AgentControlConnectPayload is the result payload for AgentControl/Agent/Connect.
+type AgentControlConnectPayload struct {
+	Endpoints  []ConnectResult
+	PrivateKey KeyValidationResult
+}
+
+// AgentControlAgentConnect checks network connectivity to agent-control service endpoints
+// and validates the local identity private key.
+type AgentControlAgentConnect struct {
+	httpGetter   requestFunc
+	configReader func(string) ([]byte, error)
+}
+
+func (p AgentControlAgentConnect) Identifier() tasks.Identifier {
+	return tasks.IdentifierFromString("AgentControl/Agent/Connect")
+}
+
+func (p AgentControlAgentConnect) Explain() string {
+	return "Check network connectivity to New Relic agent-control service endpoints and validate the local identity key"
+}
+
+func (p AgentControlAgentConnect) Dependencies() []string {
+	return []string{"AgentControl/Config/Agent"}
+}
+
+func (p AgentControlAgentConnect) Execute(_ tasks.Options, upstream map[string]tasks.Result) tasks.Result {
+	if upstream["AgentControl/Config/Agent"].Status != tasks.Success {
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: "Agent Control not detected on system.",
+		}
+	}
+
+	cfg, cfgErr := readACConfig(p.configReader)
+	if cfgErr != nil {
+		log.Debug("Could not read agent-control config, using default endpoints: " + cfgErr.Error())
+	}
+
+	opampURL, jwksURL, oauthURL := endpointsFromConfig(cfg)
+
+	opampResult := p.checkConnectivity("OpAMP", opampURL)
+	jwksResult := p.checkJWKS(jwksURL)
+	// OAuth2 token endpoint is POST-only and requires signed credentials that may be
+	// expired. We only verify TCP/TLS reachability via a GET (any HTTP response = ok).
+	oauthResult := p.checkConnectivity("OAuth2 token", oauthURL)
+	keyResult := p.checkPrivateKey(cfg, cfgErr)
+
+	payload := AgentControlConnectPayload{
+		Endpoints:  []ConnectResult{opampResult, jwksResult, oauthResult},
+		PrivateKey: keyResult,
+	}
+
+	var failures []string
+	if !opampResult.Reachable {
+		failures = append(failures, fmt.Sprintf("OpAMP (%s): %s", opampURL, opampResult.Note))
+	}
+	if !jwksResult.Reachable {
+		failures = append(failures, fmt.Sprintf("JWKS (%s): %s", jwksURL, jwksResult.Note))
+	}
+	if !oauthResult.Reachable {
+		failures = append(failures, fmt.Sprintf("OAuth2 token (%s): %s", oauthURL, oauthResult.Note))
+	}
+	if !keyResult.Valid {
+		failures = append(failures, fmt.Sprintf("identity key (%s): %s", keyResult.Path, keyResult.Note))
+	}
+
+	if len(failures) > 0 {
+		summary := "Agent Control connectivity/configuration check failed:\n"
+		for _, f := range failures {
+			summary += "  - " + f + "\n"
+		}
+		return tasks.Result{
+			Status:  tasks.Failure,
+			Summary: summary,
+			URL:     "https://docs.newrelic.com/docs/new-relic-solutions/get-started/networks/",
+			Payload: payload,
+		}
+	}
+
+	return tasks.Result{
+		Status:  tasks.Success,
+		Summary: fmt.Sprintf("All agent-control endpoints reachable and identity key valid. JWKS: %s", jwksResult.Note),
+		Payload: payload,
+	}
+}
+
+func endpointsFromConfig(cfg acConfig) (opampURL, jwksURL, oauthURL string) {
+	opampURL = defaultOpAMPEndpoint
+	jwksURL = defaultJWKSEndpoint
+	oauthURL = defaultOAuthEndpoint
+
+	if cfg.FleetControl.Endpoint != "" {
+		opampURL = cfg.FleetControl.Endpoint
+	}
+	if cfg.FleetControl.SignatureValidation.PublicKeyServerURL != "" {
+		jwksURL = cfg.FleetControl.SignatureValidation.PublicKeyServerURL
+	}
+	if cfg.FleetControl.AuthConfig.TokenURL != "" {
+		oauthURL = cfg.FleetControl.AuthConfig.TokenURL
+	}
+	return
+}
+
+// checkPrivateKey validates the local identity private key referenced in the config:
+// - file exists and is readable
+// - contains a valid PKCS8 PEM block
+// - decodes as an Ed25519 private key
+//
+// It does NOT attempt any network call or token retrieval, because the client_id
+// validity is managed backend-side and may be expired independently of the key.
+func (p AgentControlAgentConnect) checkPrivateKey(cfg acConfig, cfgErr error) KeyValidationResult {
+	if cfgErr != nil {
+		return KeyValidationResult{
+			Valid: false,
+			Note:  "config unavailable, cannot validate identity key: " + cfgErr.Error(),
+		}
+	}
+
+	path := cfg.FleetControl.AuthConfig.PrivateKeyPath
+	if path == "" {
+		return KeyValidationResult{
+			Valid: false,
+			Note:  "private_key_path not set in config",
+		}
+	}
+
+	data, err := p.configReader(path)
+	if err != nil {
+		return KeyValidationResult{
+			Path:  path,
+			Valid: false,
+			Note:  "cannot read key file: " + err.Error(),
+		}
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return KeyValidationResult{
+			Path:  path,
+			Valid: false,
+			Note:  "file does not contain a valid PEM block",
+		}
+	}
+
+	// agent-control expects PKCS8 ("PRIVATE KEY"), not OpenSSH or raw formats.
+	if block.Type != "PRIVATE KEY" {
+		return KeyValidationResult{
+			Path:  path,
+			Valid: false,
+			Note:  fmt.Sprintf("expected PKCS8 PEM type \"PRIVATE KEY\", got %q", block.Type),
+		}
+	}
+
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return KeyValidationResult{
+			Path:  path,
+			Valid: false,
+			Note:  "cannot parse PKCS8 key: " + err.Error(),
+		}
+	}
+
+	var keyType string
+	switch key.(type) {
+	case *rsa.PrivateKey:
+		return KeyValidationResult{
+			Path:  path,
+			Valid: true,
+			Note:  "valid RSA PKCS8 private key (RS256)",
+		}
+	case ed25519.PrivateKey:
+		keyType = "Ed25519"
+	case *ecdsa.PrivateKey:
+		keyType = "ECDSA"
+	default:
+		keyType = fmt.Sprintf("%T", key)
+	}
+	return KeyValidationResult{
+		Path:  path,
+		Valid: false,
+		Note:  fmt.Sprintf("%s key is not supported; agent-control requires RSA (RS256)", keyType),
+	}
+}
+
+// checkConnectivity makes a GET request and considers any HTTP response (including 4xx/5xx)
+// as "reachable" — only a connection-level error means the endpoint is unreachable.
+func (p AgentControlAgentConnect) checkConnectivity(name, url string) ConnectResult {
+	wrapper := httpHelper.RequestWrapper{
+		Method:         "GET",
+		URL:            url,
+		TimeoutSeconds: 30,
+	}
+
+	response, err := p.httpGetter(wrapper)
+	if err != nil {
+		log.Debug(fmt.Sprintf("%s endpoint unreachable: %s", name, err.Error()))
+		return ConnectResult{URL: url, Reachable: false, Note: err.Error()}
+	}
+	_ = response.Body.Close()
+
+	log.Debug(fmt.Sprintf("%s endpoint reachable, HTTP %d", name, response.StatusCode))
+	return ConnectResult{URL: url, Reachable: true, StatusCode: response.StatusCode}
+}
+
+type jwksPayload struct {
+	Keys []json.RawMessage `json:"keys"`
+}
+
+// checkJWKS makes a GET request to the JWKS endpoint and validates the response contains
+// at least one key, confirming both connectivity and that the key server is functioning.
+func (p AgentControlAgentConnect) checkJWKS(url string) ConnectResult {
+	wrapper := httpHelper.RequestWrapper{
+		Method:         "GET",
+		URL:            url,
+		TimeoutSeconds: 30,
+	}
+
+	response, err := p.httpGetter(wrapper)
+	if err != nil {
+		return ConnectResult{URL: url, Reachable: false, Note: err.Error()}
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != 200 {
+		return ConnectResult{
+			URL:        url,
+			Reachable:  false,
+			StatusCode: response.StatusCode,
+			Note:       fmt.Sprintf("unexpected HTTP %d", response.StatusCode),
+		}
+	}
+
+	var jwks jwksPayload
+	if err := json.NewDecoder(response.Body).Decode(&jwks); err != nil {
+		return ConnectResult{
+			URL:        url,
+			Reachable:  false,
+			StatusCode: response.StatusCode,
+			Note:       "invalid JWKS JSON: " + err.Error(),
+		}
+	}
+
+	if len(jwks.Keys) == 0 {
+		return ConnectResult{
+			URL:        url,
+			Reachable:  false,
+			StatusCode: response.StatusCode,
+			Note:       "JWKS response contains no keys",
+		}
+	}
+
+	return ConnectResult{
+		URL:        url,
+		Reachable:  true,
+		StatusCode: response.StatusCode,
+		Note:       fmt.Sprintf("%d public key(s) found", len(jwks.Keys)),
+	}
+}

--- a/tasks/agentcontrol/agent/logs.go
+++ b/tasks/agentcontrol/agent/logs.go
@@ -1,0 +1,100 @@
+package agentcontrol
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+const acWindowsLogDir = `C:\ProgramData\New Relic\newrelic-agent-control\log\agent-control`
+
+// AgentControlLogCollect collects agent-control logs.
+// On Linux: reads from the systemd journal via journalctl (agent-control writes to stdout by default).
+// On Windows: collects the default log file.
+type AgentControlLogCollect struct {
+	cmdExec tasks.CmdExecFunc
+}
+
+func (p AgentControlLogCollect) Identifier() tasks.Identifier {
+	return tasks.IdentifierFromString("AgentControl/Agent/Logs")
+}
+
+func (p AgentControlLogCollect) Explain() string {
+	return "Collect New Relic agent-control log files"
+}
+
+func (p AgentControlLogCollect) Dependencies() []string {
+	return []string{"AgentControl/Config/Agent"}
+}
+
+func (p AgentControlLogCollect) Execute(_ tasks.Options, upstream map[string]tasks.Result) tasks.Result {
+	if upstream["AgentControl/Config/Agent"].Status != tasks.Success {
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: "Agent Control not detected on system.",
+		}
+	}
+
+	switch runtime.GOOS {
+	case "linux":
+		return p.collectLinuxLogs()
+	case "windows":
+		return p.collectWindowsLogs()
+	default:
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: fmt.Sprintf("Log collection for agent-control is not supported on %s.", runtime.GOOS),
+		}
+	}
+}
+
+func (p AgentControlLogCollect) collectLinuxLogs() tasks.Result {
+	output, err := p.cmdExec("journalctl", "-u", "newrelic-agent-control", "--no-pager")
+	if err != nil {
+		log.Debug("journalctl failed: " + err.Error())
+		return tasks.Result{
+			Status:  tasks.Warning,
+			Summary: "Could not retrieve agent-control logs via journalctl: " + err.Error(),
+		}
+	}
+
+	stream := make(chan string)
+	go tasks.StreamBlob(string(output), stream)
+
+	return tasks.Result{
+		Status:  tasks.Success,
+		Summary: "Collected agent-control logs from journalctl.",
+		FilesToCopy: []tasks.FileCopyEnvelope{{
+			Path:       "newrelic-agent-control.log",
+			Stream:     stream,
+			Identifier: "AgentControl/Agent/Logs",
+		}},
+	}
+}
+
+func (p AgentControlLogCollect) collectWindowsLogs() tasks.Result {
+	if !tasks.FileExists(acWindowsLogDir) {
+		return tasks.Result{
+			Status:  tasks.Warning,
+			Summary: fmt.Sprintf("agent-control log directory not found: %s", acWindowsLogDir),
+		}
+	}
+
+	matches, err := filepath.Glob(filepath.Join(acWindowsLogDir, "*.newrelic-agent-control.log"))
+	if err != nil || len(matches) == 0 {
+		return tasks.Result{
+			Status:  tasks.Warning,
+			Summary: fmt.Sprintf("No agent-control log files found in %s", acWindowsLogDir),
+		}
+	}
+
+	log.Debug(fmt.Sprintf("Found %d agent-control log file(s) on Windows", len(matches)))
+	return tasks.Result{
+		Status:      tasks.Success,
+		Summary:     fmt.Sprintf("Collected %d agent-control log file(s) from %s.", len(matches), acWindowsLogDir),
+		FilesToCopy: tasks.StringsToFileCopyEnvelopes(matches),
+	}
+}

--- a/tasks/agentcontrol/agent/status_server.go
+++ b/tasks/agentcontrol/agent/status_server.go
@@ -1,0 +1,128 @@
+package agentcontrol
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/newrelic/newrelic-diagnostics-cli/helpers/httpHelper"
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+// AgentControlStatusServer collects the agent-control local status server output.
+type AgentControlStatusServer struct {
+	httpGetter   requestFunc
+	configReader func(string) ([]byte, error)
+}
+
+// RequestResult contains HTTP response data for a single request.
+type RequestResult struct {
+	URL        string
+	Status     string
+	StatusCode int
+	Body       string
+	Err        error
+}
+
+func (p AgentControlStatusServer) Identifier() tasks.Identifier {
+	return tasks.IdentifierFromString("AgentControl/Agent/StatusServer")
+}
+
+func (p AgentControlStatusServer) Explain() string {
+	return "Collects agent-control status server output"
+}
+
+func (p AgentControlStatusServer) Dependencies() []string {
+	return []string{}
+}
+
+func (p AgentControlStatusServer) Execute(_ tasks.Options, _ map[string]tasks.Result) tasks.Result {
+	statusURL := p.resolveStatusURL()
+
+	result := makeRequest(statusURL, p.httpGetter)
+
+	if result.Err != nil {
+		return tasks.Result{
+			Status:  tasks.Warning,
+			Summary: fmt.Sprintf("Could not connect to agent-control status server at %s: %s", statusURL, result.Err.Error()),
+			Payload: result,
+		}
+	}
+
+	if result.StatusCode == 200 {
+		stream := make(chan string)
+		go tasks.StreamBlob(result.Body, stream)
+
+		return tasks.Result{
+			Status:  tasks.Success,
+			Summary: fmt.Sprintf("agent-control status server response:\n%s", result.Body),
+			Payload: result,
+			FilesToCopy: []tasks.FileCopyEnvelope{{
+				Path:       "agent-control-status.json",
+				Stream:     stream,
+				Identifier: "AgentControl/Agent/StatusServer",
+			}},
+		}
+	}
+
+	return tasks.Result{
+		Status:  tasks.Warning,
+		Summary: fmt.Sprintf("Unexpected response from agent-control status server at %s: HTTP %d", statusURL, result.StatusCode),
+		Payload: result,
+	}
+}
+
+// resolveStatusURL reads host and port from the config file, falling back to defaults.
+func (p AgentControlStatusServer) resolveStatusURL() string {
+	host := defaultStatusHost
+	port := defaultStatusPort
+
+	cfg, err := readACConfig(p.configReader)
+	if err != nil {
+		log.Debug("Could not read agent-control config for status server, using defaults: " + err.Error())
+	} else {
+		if !cfg.Server.Enabled {
+			log.Debug("agent-control status server is disabled in config")
+		}
+		if cfg.Server.Host != "" {
+			host = cfg.Server.Host
+		}
+		if cfg.Server.Port != 0 {
+			port = cfg.Server.Port
+		}
+	}
+
+	return fmt.Sprintf("http://%s:%d/status", host, port)
+}
+
+func makeRequest(url string, HTTPagent requestFunc) RequestResult {
+	var body []byte
+	var status string
+	var statusCode int
+
+	wrapper := httpHelper.RequestWrapper{
+		Method:         "GET",
+		URL:            url,
+		TimeoutSeconds: 30,
+	}
+
+	response, err := HTTPagent(wrapper)
+	if err == nil {
+		status = response.Status
+		statusCode = response.StatusCode
+		body, err = io.ReadAll(response.Body)
+		if err != nil {
+			err = errors.New("read error: " + err.Error())
+		}
+		_ = response.Body.Close()
+	}
+
+	return RequestResult{
+		URL:        url,
+		Status:     status,
+		StatusCode: statusCode,
+		Body:       string(body),
+		Err:        err,
+	}
+}

--- a/tasks/agentcontrol/config/agent.go
+++ b/tasks/agentcontrol/config/agent.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"io/fs"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+type AgentControlConfigAgent struct {
+	binaryChecker binaryFunc
+}
+
+type binaryFunc func() (bool, string)
+
+type collectRoot struct {
+	base   string
+	subDir string
+}
+
+var acCollectLinux = []collectRoot{
+	{base: "/var/lib/newrelic-agent-control", subDir: "fleet-data"},
+	{base: "/etc/newrelic-agent-control", subDir: "local-data"},
+}
+
+var acCollectWindows = []collectRoot{
+	{base: `C:\ProgramData\New Relic\newrelic-agent-control`, subDir: "fleet-data"},
+	{base: `C:\Program Files\New Relic\newrelic-agent-control`, subDir: "local-data"},
+}
+
+func (p AgentControlConfigAgent) Identifier() tasks.Identifier {
+	return tasks.IdentifierFromString("AgentControl/Config/Agent")
+}
+
+func (p AgentControlConfigAgent) Explain() string {
+	return "Detect New Relic AgentControl agent"
+}
+
+func (p AgentControlConfigAgent) Dependencies() []string {
+	return []string{}
+}
+
+func (p AgentControlConfigAgent) Execute(_ tasks.Options, _ map[string]tasks.Result) tasks.Result {
+	binaryFound, binaryFilename := p.binaryChecker()
+	if !binaryFound {
+		log.Debug("No AgentControl agent found on system")
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: tasks.NoAgentDetectedSummary,
+		}
+	}
+
+	log.Debug("Identified AgentControl from binary: " + binaryFilename)
+
+	roots := acCollectLinux
+	if runtime.GOOS == "windows" {
+		roots = acCollectWindows
+	}
+
+	filesToCopy := collectYAMLFiles(roots)
+
+	return tasks.Result{
+		Status:      tasks.Success,
+		Summary:     "AgentControl agent identified from binary: " + binaryFilename,
+		FilesToCopy: filesToCopy,
+	}
+}
+
+func collectYAMLFiles(roots []collectRoot) []tasks.FileCopyEnvelope {
+	var envelopes []tasks.FileCopyEnvelope
+
+	for _, root := range roots {
+		walkDir := filepath.Join(root.base, root.subDir)
+		if !tasks.FileExists(walkDir) {
+			log.Debug("agent-control data directory not found: " + walkDir)
+			continue
+		}
+
+		_ = filepath.WalkDir(walkDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+
+			ext := strings.ToLower(filepath.Ext(path))
+			if ext != ".yaml" && ext != ".yml" {
+				return nil
+			}
+
+			// Compute path relative to base so the zip mirrors the real layout:
+			//   fleet-data/<agent>/file.yaml
+			//   local-data/<agent>/file.yaml
+			rel, relErr := filepath.Rel(root.base, path)
+			if relErr != nil {
+				log.Debug("could not compute relative path for " + path)
+				return nil
+			}
+			identifier := "AgentControl/Config/" + filepath.ToSlash(rel)
+
+			envelopes = append(envelopes, tasks.FileCopyEnvelope{
+				Path:       path,
+				Identifier: identifier,
+			})
+			return nil
+		})
+	}
+
+	return envelopes
+}
+
+// acWindowsBinaryPaths lists default install locations on Windows, where the
+// binary is typically not added to PATH by the installer.
+var acWindowsBinaryPaths = []string{
+	`C:\Program Files\New Relic\newrelic-agent-control\newrelic-agent-control.exe`,
+}
+
+func checkForBinary() (bool, string) {
+	for _, name := range []string{"newrelic-agent-control", "newrelic-agent-control.exe"} {
+		if path, err := exec.LookPath(name); err == nil {
+			log.Debug("Found agent-control binary in PATH: " + path)
+			return true, path
+		}
+	}
+
+	if runtime.GOOS == "windows" {
+		for _, path := range acWindowsBinaryPaths {
+			if tasks.FileExists(path) {
+				log.Debug("Found agent-control binary at default Windows path: " + path)
+				return true, path
+			}
+		}
+	}
+
+	log.Debug("No AgentControl binary found")
+	return false, ""
+}

--- a/tasks/agentcontrol/config/config.go
+++ b/tasks/agentcontrol/config/config.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+// RegisterWith - will register any plugins in this package
+func RegisterWith(registrationFunc func(tasks.Task, bool)) {
+	log.Debug("Registering AgentControl/Config/*")
+
+	registrationFunc(AgentControlConfigAgent{binaryChecker: checkForBinary}, true)
+	registrationFunc(AgentControlDirTree{}, true)
+}

--- a/tasks/agentcontrol/config/config_test.go
+++ b/tasks/agentcontrol/config/config_test.go
@@ -1,0 +1,139 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+func TestExecute_binaryNotFound(t *testing.T) {
+	p := AgentControlConfigAgent{
+		binaryChecker: func() (bool, string) { return false, "" },
+	}
+
+	result := p.Execute(tasks.Options{}, map[string]tasks.Result{})
+
+	if result.Status != tasks.None {
+		t.Errorf("Status = %v, want None", result.Status)
+	}
+	if result.Summary != tasks.NoAgentDetectedSummary {
+		t.Errorf("Summary = %q, want NoAgentDetectedSummary", result.Summary)
+	}
+}
+
+func TestExecute_binaryFound(t *testing.T) {
+	p := AgentControlConfigAgent{
+		binaryChecker: func() (bool, string) { return true, "/usr/bin/newrelic-agent-control" },
+	}
+
+	result := p.Execute(tasks.Options{}, map[string]tasks.Result{})
+
+	if result.Status != tasks.Success {
+		t.Errorf("Status = %v, want Success", result.Status)
+	}
+	if !strings.Contains(result.Summary, "/usr/bin/newrelic-agent-control") {
+		t.Errorf("Summary %q does not contain binary path", result.Summary)
+	}
+}
+
+// --- collectYAMLFiles ---
+
+func TestCollectYAMLFiles_emptyRoots(t *testing.T) {
+	if got := collectYAMLFiles([]collectRoot{}); len(got) != 0 {
+		t.Errorf("expected 0 envelopes, got %d", len(got))
+	}
+}
+
+func TestCollectYAMLFiles_missingDirectory(t *testing.T) {
+	roots := []collectRoot{{base: "/nonexistent/path", subDir: "fleet-data"}}
+	if got := collectYAMLFiles(roots); len(got) != 0 {
+		t.Errorf("expected 0 envelopes for missing dir, got %d", len(got))
+	}
+}
+
+func TestCollectYAMLFiles_onlyYAMLCollected(t *testing.T) {
+	tmp := t.TempDir()
+	mustWrite(t, tmp, "fleet-data/agent-control/config.yaml", "key: val")
+	mustWrite(t, tmp, "fleet-data/agent-control/notes.txt", "ignore me")
+	mustWrite(t, tmp, "fleet-data/agent-control/data.yml", "key: val")
+	mustWrite(t, tmp, "fleet-data/agent-control/binary.bin", "ignore me")
+
+	got := collectYAMLFiles([]collectRoot{{base: tmp, subDir: "fleet-data"}})
+
+	if len(got) != 2 {
+		t.Errorf("expected 2 envelopes (.yaml + .yml), got %d", len(got))
+	}
+}
+
+func TestCollectYAMLFiles_preservesSubdirStructure(t *testing.T) {
+	// Simulates a real install with agent-control + one sub-agent across both data dirs.
+	tmp := t.TempDir()
+	mustWrite(t, tmp, "fleet-data/agent-control/instance_id.yaml", "")
+	mustWrite(t, tmp, "fleet-data/agent-control/remote_config.yaml", "")
+	mustWrite(t, tmp, "fleet-data/newrelic-agent/instance_id.yaml", "")
+	mustWrite(t, tmp, "local-data/agent-control/local_config.yaml", "")
+	mustWrite(t, tmp, "local-data/newrelic-agent/local_config.yaml", "")
+
+	roots := []collectRoot{
+		{base: tmp, subDir: "fleet-data"},
+		{base: tmp, subDir: "local-data"},
+	}
+
+	envelopes := collectYAMLFiles(roots)
+	if len(envelopes) != 5 {
+		t.Fatalf("expected 5 envelopes, got %d", len(envelopes))
+	}
+
+	var got []string
+	for _, e := range envelopes {
+		got = append(got, e.Identifier)
+	}
+	sort.Strings(got)
+
+	want := []string{
+		"AgentControl/Config/fleet-data/agent-control/instance_id.yaml",
+		"AgentControl/Config/fleet-data/agent-control/remote_config.yaml",
+		"AgentControl/Config/fleet-data/newrelic-agent/instance_id.yaml",
+		"AgentControl/Config/local-data/agent-control/local_config.yaml",
+		"AgentControl/Config/local-data/newrelic-agent/local_config.yaml",
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("identifiers mismatch:\n got:  %v\nwant: %v", got, want)
+	}
+}
+
+func TestCollectYAMLFiles_zipPath(t *testing.T) {
+	// Verifies the full chain: Identifier → FileCopyEnvelope.Name() → zip path.
+	tmp := t.TempDir()
+	mustWrite(t, tmp, "fleet-data/agent-control/instance_id.yaml", "id: test")
+
+	envelopes := collectYAMLFiles([]collectRoot{{base: tmp, subDir: "fleet-data"}})
+	if len(envelopes) != 1 {
+		t.Fatalf("expected 1 envelope, got %d", len(envelopes))
+	}
+
+	got := envelopes[0].Name()
+	want := "AgentControl/Config/fleet-data/agent-control/instance_id.yaml"
+	if got != want {
+		t.Errorf("Name() = %q, want %q", got, want)
+	}
+}
+
+// mustWrite creates a file at base/relPath (using forward slashes), creating all
+// parent directories as needed, and writes content into it.
+func mustWrite(t *testing.T, base, relPath, content string) {
+	t.Helper()
+	full := filepath.Join(base, filepath.FromSlash(relPath))
+	if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/tasks/agentcontrol/config/dirtree.go
+++ b/tasks/agentcontrol/config/dirtree.go
@@ -1,0 +1,150 @@
+package config
+
+import (
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	log "github.com/newrelic/newrelic-diagnostics-cli/logger"
+	"github.com/newrelic/newrelic-diagnostics-cli/tasks"
+)
+
+// AgentControlDirTree collects a directory tree of agent-control installation paths.
+type AgentControlDirTree struct{}
+
+func (p AgentControlDirTree) Identifier() tasks.Identifier {
+	return tasks.IdentifierFromString("AgentControl/Config/DirTree")
+}
+
+func (p AgentControlDirTree) Explain() string {
+	return "Collect directory tree of New Relic agent-control installation paths"
+}
+
+func (p AgentControlDirTree) Dependencies() []string {
+	return []string{"AgentControl/Config/Agent"}
+}
+
+func (p AgentControlDirTree) Execute(_ tasks.Options, upstream map[string]tasks.Result) tasks.Result {
+	if upstream["AgentControl/Config/Agent"].Status != tasks.Success {
+		return tasks.Result{
+			Status:  tasks.None,
+			Summary: "Agent Control not detected on system.",
+		}
+	}
+
+	roots := acCollectLinux
+	if runtime.GOOS == "windows" {
+		roots = acCollectWindows
+	}
+	var dirs []string
+	for _, r := range roots {
+		dirs = append(dirs, r.base)
+	}
+
+	var sb strings.Builder
+	anyFound := false
+
+	for _, dir := range dirs {
+		if !tasks.FileExists(dir) {
+			log.Debug("agent-control directory not found: " + dir)
+			sb.WriteString(dir + " (not found)\n\n")
+			continue
+		}
+		anyFound = true
+		sb.WriteString(buildDirTree(dir))
+		sb.WriteString("\n")
+	}
+
+	if !anyFound {
+		return tasks.Result{
+			Status:  tasks.Warning,
+			Summary: fmt.Sprintf("No agent-control directories found in %v.", dirs),
+		}
+	}
+
+	stream := make(chan string)
+	go tasks.StreamBlob(sb.String(), stream)
+
+	return tasks.Result{
+		Status:  tasks.Success,
+		Summary: "Collected agent-control directory tree.",
+		FilesToCopy: []tasks.FileCopyEnvelope{{
+			Path:       "agent-control-dirtree.txt",
+			Stream:     stream,
+			Identifier: "AgentControl/Config/DirTree",
+		}},
+	}
+}
+
+type treeNode struct {
+	name     string
+	isDir    bool
+	size     int64
+	err      error
+	children []*treeNode
+}
+
+func buildDirTree(root string) string {
+	rootNode := &treeNode{name: root, isDir: true}
+	nodeByPath := map[string]*treeNode{root: rootNode}
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if path == root {
+			return nil
+		}
+		parent := filepath.Dir(path)
+		parentNode, ok := nodeByPath[parent]
+		if !ok {
+			return nil
+		}
+		node := &treeNode{name: d.Name(), isDir: d.IsDir(), err: err}
+		if err == nil && !d.IsDir() {
+			if info, infoErr := d.Info(); infoErr == nil {
+				node.size = info.Size()
+			}
+		}
+		nodeByPath[path] = node
+		parentNode.children = append(parentNode.children, node)
+		return nil
+	})
+
+	var sb strings.Builder
+	sb.WriteString(root + "\n")
+	renderNode(&sb, rootNode, "")
+	return sb.String()
+}
+
+func renderNode(sb *strings.Builder, node *treeNode, prefix string) {
+	for i, child := range node.children {
+		isLast := i == len(node.children)-1
+		connector := "├── "
+		childPrefix := prefix + "│   "
+		if isLast {
+			connector = "└── "
+			childPrefix = prefix + "    "
+		}
+		label := child.name
+		if child.err != nil {
+			label += fmt.Sprintf(" (error: %s)", child.err.Error())
+		} else if child.isDir {
+			label += "/"
+		} else {
+			label += fmt.Sprintf(" (%s)", formatSize(child.size))
+		}
+		sb.WriteString(prefix + connector + label + "\n")
+		renderNode(sb, child, childPrefix)
+	}
+}
+
+func formatSize(b int64) string {
+	switch {
+	case b < 1024:
+		return fmt.Sprintf("%d B", b)
+	case b < 1024*1024:
+		return fmt.Sprintf("%.1f KB", float64(b)/1024)
+	default:
+		return fmt.Sprintf("%.1f MB", float64(b)/(1024*1024))
+	}
+}

--- a/tasks/k8s/agentcontrol/logs.go
+++ b/tasks/k8s/agentcontrol/logs.go
@@ -62,6 +62,7 @@ func (p K8sAgentControlLogs) runCommand(namespace string) ([]byte, error) {
 			p.labelSelector,
 			"--all-containers",
 			"--prefix",
+			"--tail=-1",
 		)
 	}
 	return p.cmdExec(
@@ -73,5 +74,6 @@ func (p K8sAgentControlLogs) runCommand(namespace string) ([]byte, error) {
 		p.labelSelector,
 		"--all-containers",
 		"--prefix",
+		"--tail=-1",
 	)
 }


### PR DESCRIPTION
# Issue

NR-593462

# Goals

NRdiag recipe for AC on host (win and linux)

# Implementation Details

- AgentControl/Config/Agent — detects agent-control via PATH, known install paths, and data directory fallback; collects all YAML files from fleet-data and local-data        
  preserving the original directory structure for all registered sub-agents.                                                                                                    
- AgentControl/Agent/Connect — checks TCP/TLS reachability of the OpAMP, JWKS, and OAuth2 token endpoints (reading URLs from local_config.yaml); validates the local identity 
  private key is a readable, parseable PKCS8 key (RSA, Ed25519, or ECDSA).                                                                                                      
- AgentControl/Agent/Logs — on Linux collects logs via journalctl -u newrelic-agent-control; on Windows globs all date-rotated *.newrelic-agent-control.log files from the    
  default log directory.                                                                                                                                                        
- AgentControl/Agent/StatusServer — queries the local status server at the host/port configured in local_config.yaml (default 127.0.0.1:51200) and saves the JSON response to 
  the diagnostics zip.                                                                                                                                                          
- AgentControl/Config/DirTree — writes a formatted directory tree of all agent-control installation paths to the zip for structure inspection.


# How to Test
                                                                                                                                                         
nrdiag -suites onhost-agent-control